### PR TITLE
Fix intent bug

### DIFF
--- a/x/interchainstaking/types/validator.go
+++ b/x/interchainstaking/types/validator.go
@@ -17,11 +17,12 @@ func (v Validator) GetDelegationForDelegator(delegator string) (*Delegation, err
 
 func (di DelegatorIntent) AddOrdinal(multiplier sdk.Int, intents map[string]*ValidatorIntent) DelegatorIntent {
 	di.Ordinalize(multiplier)
+OUTER:
 	for _, i := range intents {
 		for _, j := range di.Intents {
 			if i.ValoperAddress == j.ValoperAddress {
 				j.Weight = j.Weight.Add(i.Weight)
-				continue
+				continue OUTER
 			}
 		}
 		di.Intents = append(di.Intents, i)

--- a/x/interchainstaking/types/validator_test.go
+++ b/x/interchainstaking/types/validator_test.go
@@ -56,3 +56,45 @@ func TestOrdinalizeIntentWithEqualIntents(t *testing.T) {
 	require.Equal(t, len(di.Intents), 3)
 	require.Equal(t, di.Intents[0].Weight.RoundInt(), sdk.NewInt(1000))
 }
+
+func TestAddOrdinal(t *testing.T) {
+	di := types.DelegatorIntent{Delegator: "cosmos12345667890", Intents: []*types.ValidatorIntent{}}
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper12345678", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper23456789", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper34567890", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+
+	newIntents := map[string]*types.ValidatorIntent{}
+	newIntents["cosmosvaloper12345678"] = &types.ValidatorIntent{ValoperAddress: "cosmosvaloper12345678", Weight: sdk.NewDec(1000)}
+	newIntents["cosmosvaloper34567890"] = &types.ValidatorIntent{ValoperAddress: "cosmosvaloper34567890", Weight: sdk.NewDec(2000)}
+
+	di = di.AddOrdinal(sdk.NewInt(6000), newIntents)
+
+	require.Equal(t, 3, len(di.Intents))
+
+	// feels risky fetch these by numeric index; can we guarantee ordering? DelegatorIntents should probably be a string indexed map
+	require.Equal(t, di.Intents[0].Weight, sdk.NewDec(3).QuoTruncate(sdk.NewDec(9)))
+	require.Equal(t, di.Intents[1].Weight, sdk.NewDec(2).QuoTruncate(sdk.NewDec(9)))
+	require.Equal(t, di.Intents[2].Weight, sdk.NewDec(4).QuoTruncate(sdk.NewDec(9)))
+}
+
+func TestAddOrdinalWithNewVal(t *testing.T) {
+	di := types.DelegatorIntent{Delegator: "cosmos12345667890", Intents: []*types.ValidatorIntent{}}
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper12345678", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper23456789", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+	di.Intents = append(di.Intents, &types.ValidatorIntent{ValoperAddress: "cosmosvaloper34567890", Weight: sdk.OneDec().QuoTruncate(sdk.NewDec(3))})
+
+	newIntents := map[string]*types.ValidatorIntent{}
+	// add a validator we haven't seen before here; ensure it is included in output.
+	newIntents["cosmosvaloper98765432"] = &types.ValidatorIntent{ValoperAddress: "cosmosvaloper98765432", Weight: sdk.NewDec(1000)}
+	newIntents["cosmosvaloper34567890"] = &types.ValidatorIntent{ValoperAddress: "cosmosvaloper34567890", Weight: sdk.NewDec(2000)}
+
+	di = di.AddOrdinal(sdk.NewInt(6000), newIntents)
+
+	require.Equal(t, 4, len(di.Intents))
+
+	// feels risky fetch these by numeric index; can we guarantee ordering? DelegatorIntents should probably be a string indexed map
+	require.Equal(t, di.Intents[0].Weight, sdk.NewDec(2).QuoTruncate(sdk.NewDec(9)))
+	require.Equal(t, di.Intents[1].Weight, sdk.NewDec(2).QuoTruncate(sdk.NewDec(9)))
+	require.Equal(t, di.Intents[2].Weight, sdk.NewDec(4).QuoTruncate(sdk.NewDec(9)))
+	require.Equal(t, di.Intents[3].Weight, sdk.NewDec(1).QuoTruncate(sdk.NewDec(9)))
+}


### PR DESCRIPTION
Fix bug in intent logic where we don't escape enough loops after updating an existing record, so we end up with duplicate entries. 

Also add tests for the error case.