### PR TITLE
use a default validator intent if the existing one is zero length

### DIFF
--- a/x/interchainstaking/ibc_module.go
+++ b/x/interchainstaking/ibc_module.go
@@ -160,9 +160,27 @@ func (im IBCModule) OnChanOpenAck(
 			im.keeper.SubmitTx(ctx, []sdk.Msg{&msg}, account)
 		}
 
-		// // TODO: update to use callbacks - we possibly want to do this here unless there is a better way to handle slashing? perhaps as part of valset update?
-		// delegationQuery := im.keeper.ICQKeeper.NewQuery(ctx, connectionId, zoneInfo.ChainId, "cosmos.staking.v1beta1.Query/DelegatorDelegations", map[string]string{"address": address}, sdk.NewInt(int64(im.keeper.GetParam(ctx, types.KeyDelegationsInterval)))) // this can probably be less frequent, because we manage delegations ourselves.
-		// im.keeper.ICQKeeper.SetQuery(ctx, *delegationQuery)
+		// this will be the final location for this logic (which is more of a failsafe than anything else)
+		// it is currently in keeper.go, on an abci end blocker callback, because it would require a testnet reset.
+
+		// var cb keeper.Callback = func(k keeper.Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {
+		// 	zone, found := k.GetRegisteredZoneInfo(ctx, query.GetChainId())
+		// 	if !found {
+		// 		return fmt.Errorf("no registered zone for chain id: %s", query.GetChainId())
+		// 	}
+		// 	return k.SetAccountBalance(ctx, zone, query.QueryParameters["address"], args)
+		// }
+
+		// im.keeper.ICQKeeper.MakeRequest(
+		// 	ctx,
+		// 	connectionId,
+		// 	chainId,
+		// 	"cosmos.bank.v1beta1.Query/AllBalances",
+		// 	map[string]string{"address": address},
+		// 	sdk.NewInt(int64(im.keeper.GetParam(ctx, types.KeyDelegateInterval))),
+		// 	types.ModuleName,
+		// 	cb,
+		// )
 
 	default:
 		ctx.Logger().Error("unexpected channel on portID: " + portID)

--- a/x/interchainstaking/keeper/abci.go
+++ b/x/interchainstaking/keeper/abci.go
@@ -17,4 +17,8 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 	if ctx.BlockHeight()%int64(k.GetParam(ctx, types.KeyDepositInterval)) == 0 {
 		k.IterateRegisteredZones(ctx, k.depositInterval(ctx))
 	}
+
+	if ctx.BlockHeight()%int64(k.GetParam(ctx, types.KeyDelegateInterval)) == 0 {
+		k.IterateRegisteredZones(ctx, k.delegateInterval(ctx))
+	}
 }

--- a/x/interchainstaking/keeper/delegation.go
+++ b/x/interchainstaking/keeper/delegation.go
@@ -37,16 +37,6 @@ func (k *Keeper) Delegate(ctx sdk.Context, zone types.RegisteredZone, account *t
 	return k.SubmitTx(ctx, msgs, account)
 }
 
-// func (k *Keeper) WithdrawDelegationRewards(ctx sdk.Context, zone types.RegisteredZone, account *types.ICAAccount) error {
-// 	k.Logger(ctx).Debug("Withdrawing rewards for delegate account", "account", account.GetAddress(), "zone", zone.ChainId)
-// 	delegatorRewardsDatapoint, err := k.ICQKeeper.GetDatapointForId(ctx, queryKeeper.GenerateQueryHash(zone.ConnectionId, zone.ChainId, "cosmos.distribution.v1beta1.Query/DelegationTotalRewards", map[string]string{"delegator": account.GetAddress()}))
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return k.WithdrawDelegationRewardsForResponse(ctx, zone, account, delegatorRewardsDatapoint.Value)
-
-// }
-
 func (k *Keeper) WithdrawDelegationRewardsForResponse(ctx sdk.Context, zone types.RegisteredZone, delegator string, response []byte) error {
 	var msgs []sdk.Msg
 

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -161,6 +161,37 @@ func (k Keeper) depositInterval(ctx sdk.Context) zoneItrFn {
 	}
 }
 
+// temporary: this callback should be registered when the delegate account is created, in ibc_module.go but is currently here to
+// avoid a testnet restart (same logic, just called in a different way).
+
+func (k Keeper) delegateInterval(ctx sdk.Context) zoneItrFn {
+	return func(index int64, zoneInfo types.RegisteredZone) (stop bool) {
+		for _, ica := range zoneInfo.DelegationAddresses {
+			// emit a single balance query for each delegate account
+
+			var cb Callback = func(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {
+				zone, found := k.GetRegisteredZoneInfo(ctx, query.GetChainId())
+				if !found {
+					return fmt.Errorf("no registered zone for chain id: %s", query.GetChainId())
+				}
+				return k.SetAccountBalance(ctx, zone, query.QueryParameters["address"], args)
+			}
+
+			k.ICQKeeper.MakeRequest(
+				ctx,
+				zoneInfo.ConnectionId,
+				zoneInfo.ChainId,
+				"cosmos.bank.v1beta1.Query/AllBalances",
+				map[string]string{"address": ica.Address},
+				sdk.NewInt(-1),
+				types.ModuleName,
+				cb,
+			)
+		}
+		return false
+	}
+}
+
 func (k *Keeper) GetParam(ctx sdk.Context, key []byte) uint64 {
 	var out uint64
 	k.paramStore.Get(ctx, key, &out)


### PR DESCRIPTION
- add default validator intent (if zone aggregate intent is zero-length)
- equally across all validators with < 50% commission (this will need to be a param long term)
- add function to delegate any unexplained balance in the delegate account
- temporarily trigger the above fn from endblocker on DelegateInterval. Long term this will be triggered on delegate account creation.