### PR TITLE
mint module hooks hooked up

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -277,6 +277,7 @@ cp ./${CHAIN_DIR}/${CHAINID_2}{,c}/config/genesis.json
 jq '.app_state.epochs.epochs = [{"identifier": "epoch","start_time": "0001-01-01T00:00:00Z","duration": "450s","current_epoch": "0","current_epoch_start_time": "0001-01-01T00:00:00Z","epoch_counting_started": false,"current_epoch_start_height": "0"}]' ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json > ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json.new && mv ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json{.new,}
 jq '.app_state.interchainstaking.params.delegation_account_count = 12' ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json > ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json.new && mv ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json{.new,}
 jq '.app_state.interchainstaking.params.deposit_interval = 25' ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json > ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json.new && mv ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json{.new,}
+jq '.app_state.mint.params.epoch_identifier = "epoch"' ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json > ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json.new && mv ./${CHAIN_DIR}/${CHAINID_1}/config/genesis.json{.new,}
 cp ./${CHAIN_DIR}/${CHAINID_1}{,a}/config/genesis.json
 cp ./${CHAIN_DIR}/${CHAINID_1}{,b}/config/genesis.json
 

--- a/x/mint/keeper/hooks.go
+++ b/x/mint/keeper/hooks.go
@@ -15,6 +15,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochN
 
 func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) {
 	params := k.GetParams(ctx)
+	k.Logger(ctx).Info("Mint AfterEpochEnd", "Params", params)
 
 	if epochIdentifier == params.EpochIdentifier {
 		// not distribute rewards if it's not time yet for rewards distribution

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -18,14 +18,19 @@ type Keeper struct {
 	bankKeeper       types.BankKeeper
 	distrKeeper      types.DistrKeeper
 	epochKeeper      types.EpochKeeper
-	hooks            types.MintHooks
+	hooks            types.MintHooks // should probably add a setter for this somewhere
 	feeCollectorName string
 }
 
 // NewKeeper creates a new mint Keeper instance.
 func NewKeeper(
-	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
-	ak types.AccountKeeper, bk types.BankKeeper, dk types.DistrKeeper, epochKeeper types.EpochKeeper,
+	cdc codec.BinaryCodec,
+	key sdk.StoreKey,
+	paramSpace paramtypes.Subspace,
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	dk types.DistrKeeper,
+	epochKeeper types.EpochKeeper,
 	feeCollectorName string,
 ) Keeper {
 	// ensure mint module account is set
@@ -183,8 +188,11 @@ func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error
 		return err
 	}
 
-	// call an hook after the minting and distribution of new coins
-	k.hooks.AfterDistributeMintedCoin(ctx, mintedCoin)
+	// call a hook after the minting and distribution of new coins
+	// check if hooks are set (as this requires a concrete implementation)
+	if k.hooks != nil {
+		k.hooks.AfterDistributeMintedCoin(ctx, mintedCoin)
+	}
 
 	return err
 }

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -36,8 +36,6 @@ type AppModuleBasic struct {
 	cdc codec.Codec
 }
 
-var _ module.AppModuleBasic = AppModuleBasic{}
-
 // Name returns the mint module's name.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName


### PR DESCRIPTION
- mint module loaded after distr module (dependency);
- temporarily added Burner account permission;
- MintKeeper Hooks added in EpochsKeeper;
- removed duplicate interface check;
- added logger output for dev/debug in AfterEpochEnd;
- added check for kepper.hooks (check for concrete implementation);

TODO: mint keeper hooks need setter / utilization in constructor;

Addresses #88 