### PR TITLE
go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ingenuity-build/quicksilver
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-alpha7


### PR DESCRIPTION
The idea here is that since most validators and developers are using systems that have the go1.18 compiler, we can increase consistency by just standardizing all the things on go 1.18.