### PR TITLE
Cross platform binaries, build cache

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -10,6 +10,10 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
+    strategy:
+      matrix:
+        targetos: [linux, windows]
+        arch: [amd64, arm64]
     runs-on: ubuntu-latest
     name: build quicksilver 
     steps:

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -29,7 +29,12 @@ jobs:
         run: |
           make install
 
-
+      - name: Archive quicksilver binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: quicksilverd-${{ matrix.targetos }}-${{ matrix.arch }}
+          path: |
+            build/quicksilverd*
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -58,6 +58,16 @@ jobs:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}
 
+      - name: Setup Golang caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
+
       - name: test quicksilver
         run: |
           make test

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -25,6 +25,16 @@ jobs:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}
 
+      - name: Setup Golang caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
+
       - name: Compile quicksilver
         run: |
           make install

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           name: quicksilverd-${{ matrix.targetos }}-${{ matrix.arch }}
           path: |
-            build/quicksilverd*
+            ~/go/bin/quicksilverd*
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -64,9 +64,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-golang-test-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-golang-
+            ${{ runner.os }}-golang-test-
 
       - name: test quicksilver
         run: |


### PR DESCRIPTION
- Added cross-platform binary build: `linux-amd64`, `linux-arm64`, `windows-amd64`, `windows-arm64`
- Added build caching (improves build and test time)
- Added built binaries saving as build artefacts (Github automatically creates zip file for each build platform binary)