### PR TITLE
participation-rewards bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine3.15 AS builder
+FROM golang:1.18-alpine3.15 AS builder
 RUN apk add --no-cache make git gcc musl-dev openssl-dev linux-headers 
 
 WORKDIR /src/app/

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -173,6 +173,7 @@ func SetValidatorForZone(k Keeper, ctx sdk.Context, zoneInfo types.RegisteredZon
 			CommissionRate:  validator.GetCommission(),
 			VotingPower:     validator.Tokens,
 			DelegatorShares: validator.DelegatorShares,
+			Score:           sdk.ZeroDec(),
 		})
 		zoneInfo.Validators = zoneInfo.GetValidatorsSorted()
 

--- a/x/interchainstaking/keeper/proposal_handler.go
+++ b/x/interchainstaking/keeper/proposal_handler.go
@@ -96,10 +96,10 @@ func (k Keeper) registerInterchainAccount(ctx sdk.Context, connectionId string, 
 
 // HandleUpdateZoneProposal is a handler for executing a passed community spend proposal
 func HandleUpdateZoneProposal(ctx sdk.Context, k Keeper, p *types.UpdateZoneProposal) error {
-
 	zone, found := k.GetRegisteredZoneInfo(ctx, p.ChainId)
 	if !found {
-		fmt.Errorf("Unable to get registered zone for chain id: %s", p.ChainId)
+		err := fmt.Errorf("Unable to get registered zone for chain id: %s", p.ChainId)
+		return err
 	}
 
 	for _, change := range p.Changes {

--- a/x/participationrewards/keeper/rewards_validatorSelection.go
+++ b/x/participationrewards/keeper/rewards_validatorSelection.go
@@ -268,7 +268,12 @@ func (k Keeper) calcUserValidatorSelectionAllocations(
 		uSum := sdk.NewDec(0)
 		for _, intent := range di.GetIntents() {
 			// calc overall user score
-			score := intent.Weight.Mul(zs.ValidatorScores[intent.ValoperAddress].Score)
+			score := sdk.ZeroDec()
+			if vs, exists := zs.ValidatorScores[intent.ValoperAddress]; exists {
+				if !vs.Score.IsNil() {
+					score = intent.Weight.Mul(vs.Score)
+				}
+			}
 			k.Logger(ctx).Info("user score for validator", "user", di.GetDelegator(), "validator", intent.ValoperAddress, "score", score)
 			uSum = uSum.Add(score)
 		}


### PR DESCRIPTION
- SetValidatorForZone now sets the validator score to zero;
- HandleUpdateZoneProposal now returns the error after logging;
- calcUserValidatorSelectionAllocation ensures a non-nil score;
- Dockerfile bumped Go version to 1.18;