### PR TITLE
Handle if LastEmissionHeight is nil

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -133,7 +133,7 @@ func init() {
 const (
 	// Name defines the application binary name
 	Name        = "quicksilverd"
-	upgradeName = "rhye"
+	upgradeName = "underpressure"
 )
 
 var (
@@ -695,7 +695,7 @@ func NewQuicksilver(
 		upgradeName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 
-			ctx.Logger().Info("nothing to see here o.O")
+			ctx.Logger().Info("no-op upgrade to underpressure")
 
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		},

--- a/x/interchainquery/keeper/abci.go
+++ b/x/interchainquery/keeper/abci.go
@@ -21,7 +21,7 @@ func (k Keeper) EndBlocker(ctx sdk.Context) {
 	events := sdk.Events{}
 	// emit events for periodic queries
 	k.IterateQueries(ctx, func(_ int64, queryInfo types.Query) (stop bool) {
-		if queryInfo.LastEmission.Equal(sdk.ZeroInt()) || queryInfo.LastEmission.Add(queryInfo.Period).Equal(sdk.NewInt(ctx.BlockHeight())) {
+		if queryInfo.LastEmission.IsNil() || queryInfo.LastEmission.IsZero() || queryInfo.LastEmission.Add(queryInfo.Period).Equal(sdk.NewInt(ctx.BlockHeight())) {
 			k.Logger(ctx).Info("Interchainquery event emitted", "id", queryInfo.Id)
 			event := sdk.NewEvent(
 				sdk.EventTypeMessage,

--- a/x/interchainquery/keeper/grpc_query.go
+++ b/x/interchainquery/keeper/grpc_query.go
@@ -31,7 +31,7 @@ func (k Keeper) Queries(c context.Context, req *types.QueryRequestsRequest) (*ty
 			return false, err
 		}
 
-		if query.ConnectionId == req.ConnectionId && (query.LastEmission.IsZero() || query.LastEmission.GTE(query.LastHeight)) {
+		if query.ConnectionId == req.ConnectionId && (query.LastEmission.IsNil() || query.LastEmission.IsZero() || query.LastEmission.GTE(query.LastHeight)) {
 			queries = append(queries, query)
 			return true, nil
 		}


### PR DESCRIPTION
- post upgrade, existing queries will have a nil LastEmissionHeight. Handle this case.
- add no-op upgrade handler for underpressure release.