### PR TITLE
x/epochs/types: improve (GenesisState).Validate error reporting with context

### DIFF
--- a/x/epochs/types/genesis.go
+++ b/x/epochs/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"errors"
+	"fmt"
 	"time"
 )
 
@@ -38,15 +38,15 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	epochIdentifiers := map[string]bool{}
-	for _, epoch := range gs.Epochs {
+	for i, epoch := range gs.Epochs {
 		if epoch.Identifier == "" {
-			return errors.New("epoch identifier should NOT be empty")
+			return fmt.Errorf("Value #%d: epoch identifier should NOT be empty", i+1)
 		}
 		if epochIdentifiers[epoch.Identifier] {
-			return errors.New("epoch identifier should be unique")
+			return fmt.Errorf("Value #%d: epoch identifier should be unique, got duplicate %q", i+1, epoch.Identifier)
 		}
-		if epoch.Duration == 0 {
-			return errors.New("epoch duration should NOT be 0")
+		if epoch.Duration <= 0 {
+			return fmt.Errorf("Value #%d, Identifier: %q: epoch duration should be >0", i+1, epoch.Identifier)
 		}
 		epochIdentifiers[epoch.Identifier] = true
 	}

--- a/x/epochs/types/genesis_test.go
+++ b/x/epochs/types/genesis_test.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateWithBetterContext(t *testing.T) {
+	testCases := []struct {
+		name    string
+		epochs  []EpochInfo
+		wantErr string
+	}{
+		{
+			name:    "empty identifier",
+			wantErr: "should NOT be empty",
+			epochs:  []EpochInfo{{Identifier: ""}},
+		},
+		{
+			name:    "duplicate identifiers",
+			wantErr: `Value #2: epoch identifier should be unique, got duplicate "day"`,
+			epochs: []EpochInfo{
+				{
+					Identifier: "day",
+					Duration:   time.Hour * 24,
+				},
+				{Identifier: "day"},
+			},
+		},
+		{
+			name:    "invalid duration: 0",
+			wantErr: `Value #1, Identifier: "day": epoch duration should be >0`,
+			epochs: []EpochInfo{
+				{
+					Identifier: "day",
+					StartTime:  time.Time{},
+					Duration:   0,
+				},
+			},
+		},
+		{
+			name:    "invalid duration: -2",
+			wantErr: `Value #1, Identifier: "day": epoch duration should be >0`,
+			epochs: []EpochInfo{
+				{
+					Identifier: "day",
+					Duration:   -2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			gs := NewGenesisState(tc.epochs)
+			err := gs.Validate()
+			if err == nil {
+				t.Fatal("Expecting a non-nil error")
+			}
+
+			if tc.wantErr == "" {
+				t.Fatal("WantErr is unexpectedly empty!")
+			}
+			if g, w := err.Error(), tc.wantErr; !strings.Contains(g, w) {
+				t.Errorf("Error mismatch\n\twant substring: %q\n\tGot: %s", w, g)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds human friendly index (i+1) and identifier values in .Validate
errors to improve the user experience.

Sure this isn't a security issue but it is very important for
a smooth user experience to avoid wasting time hunting for where
errors are.

Fixes #173