### PR TITLE
add missing type assertions and legacy handler

### DIFF
--- a/x/airdrop/handler.go
+++ b/x/airdrop/handler.go
@@ -1,8 +1,6 @@
 package airdrop
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -12,8 +10,18 @@ import (
 
 // NewHandler returns a handler for airdrop module messages
 func NewHandler(k keeper.Keeper) sdk.Handler {
-	return func(_ sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+	msgServer := keeper.NewMsgServerImpl(k)
+
+	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case *types.MsgClaim:
+			res, err := msgServer.Claim(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
+
+		default:
+			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized airdrop message type: %T", msg)
+		}
 	}
 }

--- a/x/airdrop/types/msgs.go
+++ b/x/airdrop/types/msgs.go
@@ -13,9 +13,7 @@ const (
 	TypeMsgClaim = "claim"
 )
 
-var (
-	_ sdk.Msg = &MsgClaim{}
-)
+var _ sdk.Msg = &MsgClaim{}
 
 // NewMsgClaim constructs a msg to claim from a zone airdrop.
 func NewMsgClaim(chainID string, action int32, fromAddress sdk.Address) *MsgClaim {

--- a/x/airdrop/types/msgs.go
+++ b/x/airdrop/types/msgs.go
@@ -13,6 +13,10 @@ const (
 	TypeMsgClaim = "claim"
 )
 
+var (
+	_ sdk.Msg = &MsgClaim{}
+)
+
 // NewMsgClaim constructs a msg to claim from a zone airdrop.
 func NewMsgClaim(chainID string, action int32, fromAddress sdk.Address) *MsgClaim {
 	return &MsgClaim{ChainId: chainID, Action: action, Address: fromAddress.String()}

--- a/x/interchainquery/module.go
+++ b/x/interchainquery/module.go
@@ -48,11 +48,6 @@ func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-// RegisterCodec registers a legacy amino codec
-func (AppModuleBasic) RegisterCodec(cdc *codec.LegacyAmino) {
-	types.RegisterLegacyAminoCodec(cdc)
-}
-
 // RegisterLegacyAminoCodec registers a legacy amino codec
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterLegacyAminoCodec(cdc)

--- a/x/interchainstaking/handler.go
+++ b/x/interchainstaking/handler.go
@@ -1,8 +1,6 @@
 package interchainstaking
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -13,9 +11,23 @@ import (
 
 // NewHandler returns a handler for interchainstaking module messages
 func NewHandler(k keeper.Keeper) sdk.Handler {
-	return func(_ sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+	msgServer := keeper.NewMsgServerImpl(k)
+
+	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case *types.MsgRequestRedemption:
+			res, err := msgServer.RequestRedemption(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
+
+		case *types.MsgSignalIntent:
+			res, err := msgServer.SignalIntent(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
+
+		default:
+			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized interchainstaking message type: %T", msg)
+		}
 	}
 }
 

--- a/x/interchainstaking/module.go
+++ b/x/interchainstaking/module.go
@@ -51,11 +51,6 @@ func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-// RegisterCodec registers a legacy amino codec
-func (AppModuleBasic) RegisterCodec(cdc *codec.LegacyAmino) {
-	types.RegisterLegacyAminoCodec(cdc)
-}
-
 // RegisterLegacyAminoCodec registers a legacy amino codec
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterLegacyAminoCodec(cdc)

--- a/x/interchainstaking/types/msgs.go
+++ b/x/interchainstaking/types/msgs.go
@@ -17,6 +17,11 @@ const (
 	TypeMsgSignalIntent      = "signalintent"
 )
 
+var (
+	_ sdk.Msg = &MsgRequestRedemption{}
+	_ sdk.Msg = &MsgSignalIntent{}
+)
+
 // NewMsgRequestRedemption - construct a msg to request redemption.
 func NewMsgRequestRedemption(value sdk.Coin, destinationAddress string, fromAddress sdk.Address) *MsgRequestRedemption {
 	return &MsgRequestRedemption{Value: value, DestinationAddress: destinationAddress, FromAddress: fromAddress.String()}

--- a/x/participationrewards/keeper/msg_server.go
+++ b/x/participationrewards/keeper/msg_server.go
@@ -10,9 +10,21 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/participationrewards/types"
 )
 
+type msgServer struct {
+	*Keeper
+}
+
+// NewMsgServerImpl returns an implementation of the MsgServer interface
+// for the provided Keeper.
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+	return &msgServer{Keeper: &keeper}
+}
+
+var _ types.MsgServer = msgServer{}
+
 // SubmitClaim is used to verify, by proof, that the given user address has a
 // claim against the given asset type for the given zone.
-func (k *Keeper) SubmitClaim(goCtx context.Context, msg *types.MsgSubmitClaim) (*types.MsgSubmitClaimResponse, error) {
+func (k msgServer) SubmitClaim(goCtx context.Context, msg *types.MsgSubmitClaim) (*types.MsgSubmitClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// fetch zone
@@ -50,7 +62,7 @@ func (k *Keeper) SubmitClaim(goCtx context.Context, msg *types.MsgSubmitClaim) (
 
 	// if we get here all data was validated; verifyClaim will write the claim to the correct store.
 	if mod, ok := k.prSubmodules[msg.ProofType]; ok {
-		if err := mod.VerifyClaim(ctx, k, msg); err != nil {
+		if err := mod.VerifyClaim(ctx, k.Keeper, msg); err != nil {
 			return nil, fmt.Errorf("claim verification failed: %v", err)
 		}
 	}

--- a/x/participationrewards/module.go
+++ b/x/participationrewards/module.go
@@ -41,11 +41,6 @@ func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-// RegisterCodec registers a legacy amino codec
-func (AppModuleBasic) RegisterCodec(cdc *codec.LegacyAmino) {
-	types.RegisterLegacyAminoCodec(cdc)
-}
-
 // RegisterLegacyAminoCodec registers a legacy amino codec
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterLegacyAminoCodec(cdc)
@@ -137,7 +132,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a gRPC query service to respond to the
 // module-specific gRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	// types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 


### PR DESCRIPTION
- missing type assertions on custom Msgs
- missing legacy handler
- remove superfluous `RegisterCodec()` method that is superceded by `RegisterLegacyAminoCodec()`