### PR TITLE
bug: fix nil balance denom determination; fixes #244

### DIFF
--- a/x/interchainstaking/keeper/callbacks_test.go
+++ b/x/interchainstaking/keeper/callbacks_test.go
@@ -1,0 +1,19 @@
+package keeper
+
+import (
+	"testing"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ingenuity-build/quicksilver/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoinFromRequestKey(t *testing.T) {
+	accAddr := utils.GenerateAccAddressForTest()
+	prefix := banktypes.CreateAccountBalancesPrefix(accAddr.Bytes())
+	query := append(prefix, []byte("denom")...)
+
+	coin, err := coinFromRequestKey(query, accAddr)
+	require.NoError(t, err)
+	require.Equal(t, "denom", coin.Denom)
+}


### PR DESCRIPTION
- fixes #244 by ensuring we add the address length to the index when returning the denom substring.
- refactor the parsing function into it's own method
- add test