### PR TITLE
Release/v0.6.6 hotfix.2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -196,7 +196,7 @@ var (
 		interchainstakingtypes.ModuleName: {authtypes.Minter, authtypes.Burner},
 		interchainquerytypes.ModuleName:   nil,
 		// TODO: Remove Burner from participationrewards - for dev/test only;
-		participationrewardstypes.ModuleName: nil,
+		participationrewardstypes.ModuleName: {authtypes.Burner},
 		airdroptypes.ModuleName:              nil,
 	}
 

--- a/x/interchainstaking/keeper/callbacks.go
+++ b/x/interchainstaking/keeper/callbacks.go
@@ -93,7 +93,7 @@ func SetEpochBlockCallback(k Keeper, ctx sdk.Context, args []byte, query icqtype
 	blockResponse := tmservice.GetLatestBlockResponse{}
 	// block response is never expected to be nil
 	if bytes.Equal(args, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (1)")
 	}
 	err := k.cdc.Unmarshal(args, &blockResponse)
 	if err != nil {
@@ -122,7 +122,7 @@ func RewardsCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Quer
 	// unmarshal request payload
 	rewardsQuery := distrtypes.QueryDelegationTotalRewardsRequest{}
 	if bytes.Equal(query.Request, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (2)")
 	}
 	err := k.cdc.Unmarshal(query.Request, &rewardsQuery)
 	if err != nil {
@@ -146,7 +146,7 @@ func DelegationsCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.
 
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{}
 	if bytes.Equal(query.Request, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (3)")
 	}
 	err := k.cdc.Unmarshal(query.Request, &delegationQuery)
 	if err != nil {
@@ -226,7 +226,7 @@ func DepositIntervalCallback(k Keeper, ctx sdk.Context, args []byte, query icqty
 	txs := tx.GetTxsEventResponse{}
 
 	if bytes.Equal(args, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (4)")
 	}
 	err := k.cdc.Unmarshal(args, &txs)
 	if err != nil {
@@ -238,7 +238,7 @@ func DepositIntervalCallback(k Keeper, ctx sdk.Context, args []byte, query icqty
 	if len(txs.GetTxs()) == types.TxRetrieveCount {
 		req := tx.GetTxsEventRequest{}
 		if bytes.Equal(query.Request, []byte("")) {
-			return fmt.Errorf("attempted to unmarshal zero length byte slice")
+			return fmt.Errorf("attempted to unmarshal zero length byte slice (5)")
 		}
 		err := k.cdc.Unmarshal(query.Request, &req)
 		if err != nil {
@@ -375,7 +375,7 @@ func DepositTx(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) err
 
 	res := icqtypes.GetTxWithProofResponse{}
 	if bytes.Equal(args, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (6)")
 	}
 	err := k.cdc.Unmarshal(args, &res)
 	if err != nil {
@@ -485,7 +485,7 @@ func AccountBalanceCallback(k Keeper, ctx sdk.Context, args []byte, query icqtyp
 func AllBalancesCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {
 	balanceQuery := banktypes.QueryAllBalancesRequest{}
 	if bytes.Equal(query.Request, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (7)")
 	}
 	err := k.cdc.Unmarshal(query.Request, &balanceQuery)
 	if err != nil {

--- a/x/interchainstaking/keeper/callbacks_test.go
+++ b/x/interchainstaking/keeper/callbacks_test.go
@@ -1,0 +1,19 @@
+package keeper
+
+import (
+	"testing"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ingenuity-build/quicksilver/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoinFromRequestKey(t *testing.T) {
+	accAddr := utils.GenerateAccAddressForTest()
+	prefix := banktypes.CreateAccountBalancesPrefix(accAddr.Bytes())
+	query := append(prefix, []byte("denom")...)
+
+	coin, err := coinFromRequestKey(query, accAddr)
+	require.NoError(t, err)
+	require.Equal(t, "denom", coin.Denom)
+}

--- a/x/interchainstaking/keeper/delegation.go
+++ b/x/interchainstaking/keeper/delegation.go
@@ -1,9 +1,6 @@
 package keeper
 
 import (
-	"bytes"
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	distrTypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -198,9 +195,6 @@ func (k *Keeper) WithdrawDelegationRewardsForResponse(ctx sdk.Context, zone *typ
 	var msgs []sdk.Msg
 
 	delegatorRewards := distrTypes.QueryDelegationTotalRewardsResponse{}
-	if bytes.Equal(response, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
-	}
 	err := k.cdc.Unmarshal(response, &delegatorRewards)
 	if err != nil {
 		return err

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -80,7 +80,7 @@ func (k *Keeper) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.Pack
 
 	for msgIndex, msgData := range txMsgData.Data {
 		if bytes.Equal(msgData.Data, []byte("")) {
-			return fmt.Errorf("unable to unmarshal msg index: %d; empty byte slice is not valid", msgIndex)
+			fmt.Printf("unable to unmarshal msg index: %d (%s); empty byte slice is not valid", msgIndex, msgData.MsgType)
 		}
 		src := msgs[msgIndex]
 		switch msgData.MsgType {
@@ -628,9 +628,6 @@ func (k *Keeper) GetValidatorForToken(ctx sdk.Context, delegatorAddress string, 
 
 func (k *Keeper) UpdateDelegationRecordsForAddress(ctx sdk.Context, zone *types.Zone, delegatorAddress string, args []byte) error {
 	var response stakingtypes.QueryDelegatorDelegationsResponse
-	if bytes.Equal(args, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
-	}
 	err := k.cdc.Unmarshal(args, &response)
 	if err != nil {
 		return err

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -131,7 +131,7 @@ func (k Keeper) AllPortConnections(ctx sdk.Context) (pcs []types.PortConnectionT
 func SetValidatorsForZone(k Keeper, ctx sdk.Context, zoneInfo types.Zone, data []byte) error {
 	validatorsRes := stakingTypes.QueryValidatorsResponse{}
 	if bytes.Equal(data, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (8)")
 	}
 	err := k.cdc.Unmarshal(data, &validatorsRes)
 	if err != nil {
@@ -190,7 +190,7 @@ func SetValidatorsForZone(k Keeper, ctx sdk.Context, zoneInfo types.Zone, data [
 func SetValidatorForZone(k Keeper, ctx sdk.Context, zoneInfo types.Zone, data []byte) error {
 	validator := stakingTypes.Validator{}
 	if bytes.Equal(data, []byte("")) {
-		return fmt.Errorf("attempted to unmarshal zero length byte slice")
+		return fmt.Errorf("attempted to unmarshal zero length byte slice (9)")
 	}
 	err := k.cdc.Unmarshal(data, &validator)
 	if err != nil {


### PR DESCRIPTION
- revert a number of empty byte slice guards introduced in #235 
- re-add participationrewards burn permission temporarily