### PR TITLE
x/interchainstaking/types: add further tests + fix index out of range bugs for empty Allocations

### DIFF
--- a/x/interchainstaking/types/delegation.go
+++ b/x/interchainstaking/types/delegation.go
@@ -69,12 +69,18 @@ func (d Delegation) GetValidatorAddr() sdk.ValAddress {
 // -------------------------------------------------------------------------
 // DelegationCandidates
 
-func (a Allocations) DetermineThreshold() sdk.Int {
-	return a.SortedByAmount()[int(float64(0.33)*float64(len(a)))].SumAll()
+func (a Allocations) DetermineThreshold() (th sdk.Int) {
+	if len(a) != 0 {
+		th = a.SortedByAmount()[int(float64(0.33)*float64(len(a)))].SumAll()
+	}
+	return th
 }
 
-func (a Allocations) SmallestBin() Allocation {
-	return *a.SortedByAmount()[0]
+func (a Allocations) SmallestBin() (alloc Allocation) {
+	if len(a) != 0 {
+		alloc = *a.SortedByAmount()[0]
+	}
+	return alloc
 }
 
 func (a Allocations) FindAccountForDelegation(validatorAddress string, coin sdk.Coin) (string, Allocations) {

--- a/x/interchainstaking/types/delegation_test.go
+++ b/x/interchainstaking/types/delegation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
@@ -77,6 +78,157 @@ func TestAllocationsSub(t *testing.T) {
 			t.Errorf("remainder mismatch between expected %s and actual %s", tc.Remainder, remainder)
 		}
 	}
+}
+
+func TestRoundtripDelegationMarshalToUnmarshal(t *testing.T) {
+	del1 := types.NewDelegation(
+		"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+		"cosmos1ssrxxe4xsls57ehrkswlkhlkcverf0p0fpgyhzqw0hfdqj92ynxsw29r6e",
+		sdk.NewCoin("uqck", sdk.NewInt(300)),
+	)
+
+	wantDelAddr := (sdk.AccAddress)([]byte{0x84, 0xbf, 0xf8, 0x4c, 0x7d, 0xda, 0xd1, 0x1c, 0xb8, 0xc0, 0x73, 0x86, 0xe9, 0x19, 0x28, 0xc5, 0x67, 0x5c, 0xa4, 0xbc})
+	require.Equal(t, wantDelAddr, del1.GetDelegatorAddr(), "mismatch in delegator address")
+
+	wantValAddr := (sdk.ValAddress)([]byte{
+		0x84, 0x06, 0x63, 0x66, 0xa6, 0x87, 0xe1, 0x4f, 0x66, 0xe3, 0xb4,
+		0x1d, 0xfb, 0x5f, 0xf6, 0xc3, 0x32, 0x34, 0xbc, 0x2f, 0x48, 0x50,
+		0x4b, 0x88, 0x0e, 0x7d, 0xd2, 0xd0, 0x48, 0xaa, 0x24, 0xcd,
+	})
+	require.Equal(t, wantValAddr, del1.GetValidatorAddr(), "mismatch in validator address")
+
+	marshaledDelBytes := types.MustMarshalDelegation(types.ModuleCdc, del1)
+	unmarshaledDel := types.MustUnmarshalDelegation(types.ModuleCdc, marshaledDelBytes)
+	require.Equal(t, del1, unmarshaledDel, "Roundtripping: marshal->unmarshal should produce the same delegation")
+
+	// Finally ensure that the 2nd round marshaled bytes equal the original ones.
+	marshalDelBytes2ndRound := types.MustMarshalDelegation(types.ModuleCdc, unmarshaledDel)
+	require.Equal(t, marshaledDelBytes, marshalDelBytes2ndRound, "all the marshaled bytes should be equal!")
+}
+
+func TestAllocationsMethods(t *testing.T) {
+	allocs := types.Allocations{
+		{
+			"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(300)),
+				sdk.NewCoin("uqck", sdk.NewInt(400000)),
+			),
+		},
+		{
+			"cosmosvaloper1pyfmqnramtg7ewxqwwrwyxfgc4n5ef9p2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(100)),
+				sdk.NewCoin("uqck", sdk.NewInt(700000)),
+			),
+		},
+		{
+			"cosmosvaloper1ajllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("mqck", sdk.NewInt(300)),
+				sdk.NewCoin("pqck", sdk.NewInt(400000)),
+			),
+		},
+	}
+
+	// 1. Check that the sums for various denominations are correct.
+	qckSum := allocs.SumForDenom("qck")
+	wantQCKSum := sdk.NewInt(300 + 100)
+	require.Equal(t, wantQCKSum, qckSum, "qck sum mismatch")
+	uqckSum := allocs.SumForDenom("uqck")
+	wantuQCKSum := sdk.NewInt(400000 + 700000)
+	require.Equal(t, wantuQCKSum, uqckSum, "uqck sum mismatch")
+
+	// 2. Test that sorted returns values sorted by addresses.
+	unsortedAllocs := make(types.Allocations, len(allocs))
+	copy(unsortedAllocs, allocs)
+	gotAllocsSortedByAddrs := unsortedAllocs.Sorted()
+	require.NotEqual(t, allocs, gotAllocsSortedByAddrs, "allocs sorted by addrs mismatch")
+	wantAllocsSortedByAddrs := types.Allocations{
+		{
+			"cosmosvaloper1ajllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("mqck", sdk.NewInt(300)),
+				sdk.NewCoin("pqck", sdk.NewInt(400000)),
+			),
+		},
+		{
+			"cosmosvaloper1pyfmqnramtg7ewxqwwrwyxfgc4n5ef9p2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(100)),
+				sdk.NewCoin("uqck", sdk.NewInt(700000)),
+			),
+		},
+		{
+			"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(300)),
+				sdk.NewCoin("uqck", sdk.NewInt(400000)),
+			),
+		},
+	}
+	require.Equal(t, wantAllocsSortedByAddrs, gotAllocsSortedByAddrs, "allocs sorted by addrs mismatch")
+
+	// 3. Test that sortedByAmount sorts values firstly by addr then by value.
+	copy(unsortedAllocs, allocs)
+	gotAllocsSortedByAmount := unsortedAllocs.SortedByAmount()
+	require.NotEqual(t, allocs, gotAllocsSortedByAmount, "allocs sorted by amount mismatch")
+	wantAllocsSortedByAmount := types.Allocations{
+		{
+			"cosmosvaloper1ajllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("mqck", sdk.NewInt(300)),
+				sdk.NewCoin("pqck", sdk.NewInt(400000)),
+			),
+		},
+		{
+			"cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(300)),
+				sdk.NewCoin("uqck", sdk.NewInt(400000)),
+			),
+		},
+		{
+			"cosmosvaloper1pyfmqnramtg7ewxqwwrwyxfgc4n5ef9p2lcnj0",
+			sdk.NewCoins(
+				sdk.NewCoin("qck", sdk.NewInt(100)),
+				sdk.NewCoin("uqck", sdk.NewInt(700000)),
+			),
+		},
+	}
+	require.Equal(t, wantAllocsSortedByAmount, gotAllocsSortedByAmount, "allocs sorted by amount mismatch")
+
+	// 4. Evaluate the total sum but bucketed by denominations.
+	wantSum := sdk.Coins{
+		sdk.NewCoin("mqck", sdk.NewInt(300)),
+		sdk.NewCoin("pqck", sdk.NewInt(400000)),
+		sdk.NewCoin("qck", sdk.NewInt(400)),
+		sdk.NewCoin("uqck", sdk.NewInt(1100000)),
+	}
+	gotSum := gotAllocsSortedByAmount.Sum()
+	require.Equal(t, wantSum, gotSum, "mismatch in sum bucketed by denomination")
+
+	// 5. Evalute the total sum regardless of sum.
+	gotSumAll := allocs.SumAll()
+	wantSumAll := sdk.NewInt(100 + 300 + 300 + 400000 + 400000 + 700000)
+	require.Equal(t, wantSumAll, gotSumAll, "mismatch in sumAll values")
+
+	// 6. Evaluate threshold.
+	gotThreshold := gotAllocsSortedByAmount.DetermineThreshold()
+	// 6.1. Find the 1/3 item with all its sums, which would be the 0th item in wantAllocsSortedByAmount
+	// and then its .SumAll value of: 300 + 400000.
+	wantThreshold := sdk.NewInt(300 + 400000)
+	require.Equal(t, wantThreshold, gotThreshold, "mismatch in threshold values")
+
+	// 7. Evaluate smallest bin.
+	gotSBin1 := gotAllocsSortedByAmount.SmallestBin()
+	wantSBin := *gotAllocsSortedByAmount[0]
+	require.Equal(t, wantSBin, gotSBin1, "mismatch in smallest bin values")
+
+	// 7.5. Smallest bin value for an empty allocations object, shoould not panic.
+	got0SBin := (types.Allocations{}).SmallestBin()
+	want0SBin := types.Allocation{}
+	require.Equal(t, want0SBin, got0SBin, "mismatch in smallest bin values for empty allocations object")
 }
 
 // func TestFindAccountForDelegation(t *testing.T) {

--- a/x/interchainstaking/types/msgs_test.go
+++ b/x/interchainstaking/types/msgs_test.go
@@ -1,0 +1,113 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
+)
+
+func TestIntentsFromString(t *testing.T) {
+	// 1. Ensure we can properly parse intents with their weights.
+	intents, err := types.IntentsFromString("0.3cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0,0.3cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf,0.4cosmosvaloper1a3yjj7d3qnx4spgvjcwjq9cw9snrrrhu5h6jll")
+	require.Nil(t, err, "expecting a nil error")
+
+	wantIntents := []*types.ValidatorIntent{
+		{
+			ValoperAddress: "cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+			Weight:         sdk.MustNewDecFromStr("0.3"),
+		},
+		{
+			ValoperAddress: "cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf",
+			Weight:         sdk.MustNewDecFromStr("0.3"),
+		},
+		{
+			ValoperAddress: "cosmosvaloper1a3yjj7d3qnx4spgvjcwjq9cw9snrrrhu5h6jll",
+			Weight:         sdk.MustNewDecFromStr("0.4"),
+		},
+	}
+	require.Equal(t, wantIntents, intents, "intents mismatch")
+
+	// 2. Ensure that if the weights don't add up to 1.0 that it fails.
+	// 2.1. Greater than 1.0
+	malIntents, err := types.IntentsFromString("1.3cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0,2.3cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf,3.4cosmosvaloper1a3yjj7d3qnx4spgvjcwjq9cw9snrrrhu5h6jll")
+	require.Nil(t, malIntents, "expecting nil intents")
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.Contains(t, err.Error(), "combined weight must be 1.0")
+
+	// 2.2. Less than 1.0
+	malIntents, err = types.IntentsFromString("0.03cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0,0.3cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf,0.2cosmosvaloper1a3yjj7d3qnx4spgvjcwjq9cw9snrrrhu5h6jll")
+	require.Nil(t, malIntents, "expecting nil intents")
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.Contains(t, err.Error(), "combined weight must be 1.0")
+
+	// 3. Invalid intent strings not matching: (\d.\d)(.+1\w+) are rejected
+	malIntents, err = types.IntentsFromString("foo,bar,few")
+	require.Nil(t, malIntents, "expecting nil intents")
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.Contains(t, err.Error(), "invalid intents string")
+
+	fromAddr := (sdk.AccAddress)([]byte{0x84, 0xbf, 0xf8, 0x4c, 0x7d, 0xda, 0xd1, 0x1c, 0xb8, 0xc0, 0x73, 0x86, 0xe9, 0x19, 0x28, 0xc5, 0x67, 0x5c, 0xa4, 0xbc})
+	sigIntent := types.NewMsgSignalIntent("quicksilver", intents, fromAddr)
+	err = sigIntent.ValidateBasic()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	require.Nil(t, err)
+
+	// Check the router key.
+	gotRoute := sigIntent.Route()
+	wantRoute := "interchainstaking"
+	require.Equal(t, wantRoute, gotRoute, "mismatch in route")
+
+	// Check the type.
+	gotType := sigIntent.Type()
+	wantType := "signalintent"
+	require.Equal(t, wantType, gotType, "mismatch in type")
+
+	// Check the signBytes.
+	signBytes := sigIntent.GetSignBytes()
+	require.True(t, len(signBytes) != 0, "expecting signBytes to be produced")
+
+	// Signers should return the from address.
+	gotSigners := sigIntent.GetSigners()
+	wantSigners := []sdk.AccAddress{fromAddr}
+	require.Equal(t, wantSigners, gotSigners, "mismatch in signers")
+}
+
+func TestIntentsFromStringInvalidValoperAddressesFailsOnValidate(t *testing.T) {
+	negativeIntents, err := types.IntentsFromString("0.5cosmosvaloper1sjllsnramtg7ewxqwwrwjxfgc4n4ef9u2lcnp0,-0.5cosmosvaloper156g8f9837p7d4c46p8yt3rlals9c5vuurfrrzf")
+	require.Nil(t, negativeIntents, "expecting nil intents")
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.Contains(t, err.Error(), "must not be negative")
+
+	// The valoper addresses have invalid checksums, but they'll only be caught on invoking .ValidateBasic()
+	intents, err := types.IntentsFromString("0.5cosmosvaloper1sjllsnramtg7ewxqwwrwjxfgc4n4ef9u2lcnp0,0.5cosmosvaloper156g8f9837p7d4c46p8yt3rlals9c5vuurfrrzf")
+	require.Nil(t, err, "expecting a nil error")
+
+	wantIntents := []*types.ValidatorIntent{
+		{
+			ValoperAddress: "cosmosvaloper1sjllsnramtg7ewxqwwrwjxfgc4n4ef9u2lcnp0",
+			Weight:         sdk.MustNewDecFromStr("0.5"),
+		},
+		{
+			ValoperAddress: "cosmosvaloper156g8f9837p7d4c46p8yt3rlals9c5vuurfrrzf",
+			Weight:         sdk.MustNewDecFromStr("0.5"),
+		},
+	}
+	require.Equal(t, wantIntents, intents, "intents mismatch")
+
+	// Mutate the weight to make it greater than 1.0
+	intents[0].Weight = sdk.MustNewDecFromStr("1.7")
+	intents[1].Weight = sdk.MustNewDecFromStr("-0.5")
+
+	sigIntent := types.NewMsgSignalIntent("", intents,
+		(sdk.AccAddress)([]byte{0x84, 0xbf, 0xf8, 0x4c, 0x7d, 0xda, 0xd1, 0x1c, 0xb8, 0xc0, 0x73, 0x86, 0xe9, 0x19, 0x28, 0xc5, 0x67, 0x5c, 0xa4, 0xbc}))
+	sigIntent.FromAddress = "abcdefghi"
+	err = sigIntent.ValidateBasic()
+	require.NotNil(t, err, "expecting a non-nil error")
+	require.Contains(t, err.Error(), "invalid checksum")
+	require.Contains(t, err.Error(), "undefined")
+}


### PR DESCRIPTION
Addresses parts of Orijtech Inc audit findings, by adding more tests and coverage and found 2 bugs that could cause crashes when empty allocations are used. Instead of runtime errors, returns the empty object, and added tests to check for this condition.