### PR TITLE
x/interchainstaking/keeper: test zones roundtrip + fix bug in GetZoneForPerformanceAccount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.7.0 // indirect
 	github.com/confio/ics23/go v0.7.0 // indirect
 	github.com/cosmos/btcutil v1.0.4 // indirect
+	github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.17.3 // indirect
@@ -68,7 +69,7 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/gateway v1.1.0 // indirect
-	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
@@ -124,9 +125,9 @@ require (
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
-	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
+	golang.org/x/exp v0.0.0-20220914170420-dc92f8653013 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
 github.com/cosmos/cosmos-proto v1.0.0-alpha7 h1:yqYUOHF2jopwZh4dVQp3xgqwftE5/2hkrwIV6vkUbO0=
 github.com/cosmos/cosmos-proto v1.0.0-alpha7/go.mod h1:dosO4pSAbJF8zWCzCoTWP7nNsjcvSUBQmniFxDg5daw=
+github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1 h1:6YvzjQtc+cDwCe9XwYPPa8zFCxNG79N7vmCjpK+vGOg=
+github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1/go.mod h1:JUMM2MxF9wuwzRWZJjb8BjXsn1BmPmdBd3a75pIct4I=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -436,6 +438,7 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529 h1:2voWjNECnrZRbfwXxHB1/j8wa6xdKn85B5NzgVL/pTU=
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1203,6 +1206,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e h1:rMqLP+9XLy+LdbCXHjJHAmTfXCr93W7oruWA6Hq1Alc=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20220914170420-dc92f8653013 h1:ZjglnWxEUdPyXl4o/j4T89SRCI+4X6NW6185PNLEOF4=
+golang.org/x/exp v0.0.0-20220914170420-dc92f8653013/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1439,6 +1444,8 @@ golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -116,7 +116,7 @@ func (k Keeper) GetZoneForDelegateAccount(ctx sdk.Context, address string) *type
 func (k Keeper) GetZoneForPerformanceAccount(ctx sdk.Context, address string) *types.Zone {
 	var zone *types.Zone
 	k.IterateZones(ctx, func(_ int64, zoneInfo types.Zone) (stop bool) {
-		if zoneInfo.PerformanceAddress.Address == address {
+		if zoneInfo.PerformanceAddress != nil && zoneInfo.PerformanceAddress.Address == address {
 			zone = &zoneInfo
 			return true
 		}

--- a/x/interchainstaking/keeper/zones_test.go
+++ b/x/interchainstaking/keeper/zones_test.go
@@ -2,13 +2,171 @@ package keeper_test
 
 import (
 	"fmt"
+	"io"
+	"sort"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/exp/maps"
 
+	"github.com/ingenuity-build/quicksilver/app"
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/keeper"
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
+
+func newQuicksilver(t *testing.T) *app.Quicksilver {
+	return app.NewQuicksilver(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		io.Discard,
+		true,
+		map[int64]bool{},
+		t.TempDir(),
+		5,
+		app.MakeEncodingConfig(),
+		simapp.EmptyAppOptions{},
+	)
+}
+
+func TestKeeperWithZonesRoundTrip(t *testing.T) {
+	app := newQuicksilver(t)
+
+	chainID := "quicksilver-1"
+	kpr := app.InterchainstakingKeeper
+	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
+
+	// 1. Check for a zone without having stored anything.
+	zone, ok := kpr.GetZone(ctx, chainID)
+	require.False(t, ok, "No zone stored in the keeper")
+	require.Equal(t, types.Zone{}, zone, "Expecting the blank zone")
+
+	// 2. Now set a zone and ensure it is retrieved.
+	zone = types.Zone{
+		ConnectionId: "conn-test",
+		ChainId:      chainID,
+		LocalDenom:   "uqck",
+		BaseDenom:    "qck",
+	}
+	kpr.SetZone(ctx, &zone)
+	gotZone, ok := kpr.GetZone(ctx, chainID)
+	require.True(t, ok, "expected to retrieve a zone")
+	require.NotEqual(t, types.Zone{}, gotZone, "Expecting a non-blank zone")
+	require.Equal(t, zone, gotZone, "Expecting the stored zone")
+
+	// 3. Delete the zone then try to retrieve it.
+	kpr.DeleteZone(ctx, chainID)
+	zone, ok = kpr.GetZone(ctx, chainID)
+	require.False(t, ok, "No zone stored anymore in the keeper")
+	require.Equal(t, types.Zone{}, zone, "Expecting the blank zone")
+
+	// 4. Store many zones in the keeper, then retrieve them by chainID.
+	nzones := 10
+	chainIDPrefix := "quicksilver-"
+	indexToZone := make(map[int64]types.Zone, nzones)
+	for i := 0; i < nzones; i++ {
+		chainID := fmt.Sprintf("%s-%d", chainIDPrefix, i)
+		zone := types.Zone{
+			ConnectionId: "conn-test",
+			ChainId:      chainID,
+			LocalDenom:   "qck",
+			BaseDenom:    "qck",
+			DelegationAddresses: []*types.ICAAccount{
+				{
+					Address: "cosmos1ssrxxe4xsls57ehrkswlkhlkcverf0p0fpgyhzqw0hfdqj92ynxsw29r6e",
+					Balance: sdk.NewCoins(
+						sdk.NewCoin("qck", sdk.NewInt(100)),
+						sdk.NewCoin("uqck", sdk.NewInt(700000)),
+					),
+				},
+			},
+		}
+		kpr.SetZone(ctx, &zone)
+		gotZone, ok := kpr.GetZone(ctx, chainID)
+		require.True(t, ok, "expected to retrieve the correct zone")
+		require.NotEqual(t, types.Zone{}, gotZone, "Expecting a non-blank zone")
+		require.Equal(t, zone, gotZone, "Expecting the stored zone")
+
+		// Save the zone for later comparisons.
+		indexToZone[int64(i)] = zone
+	}
+	require.Equal(t, nzones, len(indexToZone), "expecting unique nzones")
+
+	// 5.1. Invoke Iterate on zones.
+	gotZonesMapping := make(map[int64]types.Zone, nzones)
+	kpr.IterateZones(ctx, func(index int64, zone types.Zone) bool {
+		gotZonesMapping[index] = zone
+		return false
+	})
+
+	require.Equal(t, nzones, len(gotZonesMapping), "expecting unique nzones")
+	require.Equal(t, indexToZone, gotZonesMapping, "expecting the zones mapped by index to match")
+
+	// 5.2. List all zones.
+	gotAllZones := kpr.AllZones(ctx)
+	wantAllZones := maps.Values(gotZonesMapping)
+	require.Equal(t, nzones, len(gotAllZones), "expecting unique nzones")
+	// Sort them for determinism
+	sort.Slice(gotAllZones, func(i, j int) bool {
+		zi, zj := gotAllZones[i], gotAllZones[j]
+		return zi.ChainId < zj.ChainId
+	})
+	sort.Slice(wantAllZones, func(i, j int) bool {
+		zi, zj := wantAllZones[i], wantAllZones[j]
+		return zi.ChainId < zj.ChainId
+	})
+	require.Equal(t, wantAllZones, gotAllZones, "expecting the zones to match")
+
+	// 6. Test performance accounts.
+	perfAcctZone := indexToZone[4]
+	perfAcctZone.PerformanceAddress = &types.ICAAccount{
+		Address: "cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+		Balance: sdk.NewCoins(
+			sdk.NewCoin("qck", sdk.NewInt(800)),
+			sdk.NewCoin("uqck", sdk.NewInt(900000)),
+		),
+	}
+	kpr.SetZone(ctx, &perfAcctZone)
+	gotPerfAcctZone := kpr.GetZoneForPerformanceAccount(ctx, perfAcctZone.PerformanceAddress.Address)
+	require.Equal(t, &perfAcctZone, gotPerfAcctZone, "expecting a match in performance accounts")
+	// Try with a non-existent performance address, it should return nil.
+	gotPerfAcctZone = kpr.GetZoneForPerformanceAccount(ctx, "non-existent")
+	require.Nil(t, gotPerfAcctZone, "expecting no match in the performance account")
+	// Try with a non-existent performance address but that of the performance zone.
+	gotPerfAcctZone = kpr.GetZoneForPerformanceAccount(ctx, perfAcctZone.DelegationAddresses[0].Address)
+	require.Nil(t, gotPerfAcctZone, "expecting no match in the performance account")
+
+	// 7.1. Test delegated amounts.
+	firstZone := gotAllZones[0]
+	gotDelAmt := kpr.GetDelegatedAmount(ctx, &firstZone)
+	// No delegations set so nothing expected.
+	zeroDelAmt := sdk.NewCoin(firstZone.BaseDenom, sdk.NewInt(0))
+	require.Equal(t, zeroDelAmt, gotDelAmt, "expecting 0")
+
+	// 7.2. Set some delegations.
+	del1 := types.Delegation{
+		Amount:            sdk.NewCoin(firstZone.BaseDenom, sdk.NewInt(17000)),
+		DelegationAddress: "cosmos1ssrxxe4xsls57ehrkswlkhlkcverf0p0fpgyhzqw0hfdqj92ynxsw29r6e",
+		Height:            10,
+		ValidatorAddress:  "cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0",
+	}
+	kpr.SetDelegation(ctx, &firstZone, del1)
+
+	// 7.3. Retrieve the delegation now, it should be set.
+	gotDelAmt = kpr.GetDelegatedAmount(ctx, &firstZone)
+	require.NotEqual(t, zeroDelAmt, gotDelAmt, "expecting a match in delegation amounts")
+	wantDelAmt := sdk.NewCoin(firstZone.BaseDenom, sdk.NewInt(17000))
+	require.Equal(t, wantDelAmt, gotDelAmt, "expecting 17000 as the delegation amount")
+
+	// Zone for delegation account.
+	zone4Del := kpr.GetZoneForDelegateAccount(ctx, del1.DelegationAddress)
+	require.NotNil(t, zone4Del, "expecting a non-nil zone back")
+	require.Equal(t, &firstZone, zone4Del, "expectign equivalent zones")
+}
 
 // func TestApplyDeltasToIntent(t *testing.T) {
 


### PR DESCRIPTION
Addresses part of Orijtech Inc's cybersecurity audit to add more tests. Adds tests for roundtripping zones: storing and retrieving multiple zones. While here found and fixed a bug with (Keeper).GetZoneForPerformanceAccount in which if a zone was stored without a PerformanceAddress set, the code could panic because it didn't check for nil values before dereferencing the associated field .Address.