### PR TITLE
Allow COSMOS_BUILD_OPTIONS to be set externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 DOCKER_BUILDKIT=1
-COSMOS_BUILD_OPTIONS=""
+COSMOS_BUILD_OPTIONS ?= ""
 PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 VERSION=$(shell git describe --tags | head -n1)


### PR DESCRIPTION
Allow users to set build options without manually editing the Makefile