### PR TITLE
update wasmvm lib to v1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Cosmwasm - download correct libwasmvm version
 RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | cut -d ' ' -f 2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.$(uname -m).a \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvm_muslc.$(uname -m).a \
       -O /lib/libwasmvm_muslc.a
 
 # Cosmwasm - verify checksum
-RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/checksums.txt -O /tmp/checksums.txt && \
+RUN wget https://github.com/CosmWasm/wasmvm/releases/download/$(WASMVM_VERSION)/checksums.txt -O /tmp/checksums.txt && \
     sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep $(uname -m) | cut -d ' ' -f 1)
 
 COPY . .


### PR DESCRIPTION
- wasmvm library downloaded and included by the docker container bumped to the correct version.