### PR TITLE
fix deposit address setWithdrawalAddress callback

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -733,15 +733,14 @@ func (k *Keeper) HandleUpdatedWithdrawAddress(ctx sdk.Context, msg sdk.Msg) erro
 		if zone == nil {
 			if ctx.ChainID() == "quicksilver-2" && ctx.BlockHeight() < 248000 {
 				return errors.New("unable to find zone") // mirror existing behaviour before 248000
-			} else {
-				// after 248000 correctly handle SetWithdrawalAddress callback.
-				zone = k.GetZoneForDepositAccount(ctx, original.DelegatorAddress)
-				if zone == nil {
-					return errors.New("unable to find zone")
-				}
-				if err := zone.DepositAddress.SetWithdrawalAddress(original.WithdrawAddress); err != nil {
-					return err
-				}
+			}
+			// after 248000 correctly handle SetWithdrawalAddress callback.
+			zone = k.GetZoneForDepositAccount(ctx, original.DelegatorAddress)
+			if zone == nil {
+				return errors.New("unable to find zone")
+			}
+			if err := zone.DepositAddress.SetWithdrawalAddress(original.WithdrawAddress); err != nil {
+				return err
 			}
 		}
 		if err := zone.PerformanceAddress.SetWithdrawalAddress(original.WithdrawAddress); err != nil {

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -133,6 +133,18 @@ func (k Keeper) GetZoneForPerformanceAccount(ctx sdk.Context, address string) *t
 	return zone
 }
 
+func (k Keeper) GetZoneForDepositAccount(ctx sdk.Context, address string) *types.Zone {
+	var zone *types.Zone
+	k.IterateZones(ctx, func(_ int64, zoneInfo types.Zone) (stop bool) {
+		if zoneInfo.DepositAddress != nil && zoneInfo.DepositAddress.Address == address {
+			zone = &zoneInfo
+			return true
+		}
+		return false
+	})
+	return zone
+}
+
 func (k Keeper) EnsureICAsActive(ctx sdk.Context, zone *types.Zone) error {
 	k.Logger(ctx).Info("Ensuring ICAs for zone", "zone", zone.ChainId)
 	if err := k.EnsureICAActive(ctx, zone, zone.DepositAddress); err != nil {


### PR DESCRIPTION
## 1. Summary
Fixes:
- Fixes the logic to set ICA account withdrawal address. Introduced by fixing a typo in v1.2.1  


## 2.Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

- 

## 4. How to test/use



## 5. Checklist

- [ ] Does the Readme need to be updated?
- [ ] Have tests been added to cover the change

## 6. Limitations (optional)

N/A

## 7. Future Work (optional)

N/A