### PR TITLE
fix: account keeper address prefix

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -146,6 +146,8 @@ import (
 	tokenfactorytypes "github.com/ingenuity-build/quicksilver/x/tokenfactory/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
+
+	appconfig "github.com/ingenuity-build/quicksilver/cmd/config"
 )
 
 func Init() {
@@ -398,7 +400,7 @@ func NewQuicksilver(
 
 	// use custom account for contracts
 	app.AccountKeeper = authkeeper.NewAccountKeeper(
-		appCodec, keys[authtypes.StoreKey], app.GetSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms, sdk.Bech32MainPrefix,
+		appCodec, keys[authtypes.StoreKey], app.GetSubspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, maccPerms, appconfig.Bech32PrefixAccAddr,
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.BlockedAddrs(),

--- a/cmd/quicksilverd/main.go
+++ b/cmd/quicksilverd/main.go
@@ -41,4 +41,5 @@ func setupConfig() {
 	cmdcfg.SetBech32Prefixes(config)
 	cmdcfg.SetBip44CoinType(config)
 	cmdcfg.SetWasmConfig(config)
+	config.Seal()
 }

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -37,16 +37,16 @@ type KeeperTestSuite struct {
 }
 
 // Setup sets up basic environment for suite (App, Ctx, and test accounts)
-func (s *KeeperTestSuite) Setup() {
+func (suite *KeeperTestSuite) Setup() {
 	cmdcfg.SetBech32Prefixes(sdk.GetConfig())
-	s.App = app.Setup(s.T(), false)
-	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "quick-1", Time: time.Now().UTC()})
-	s.QueryHelper = &baseapp.QueryServiceTestHelper{
-		GRPCQueryRouter: s.App.GRPCQueryRouter(),
-		Ctx:             s.Ctx,
+	suite.App = app.Setup(suite.T(), false)
+	suite.Ctx = suite.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "quick-1", Time: time.Now().UTC()})
+	suite.QueryHelper = &baseapp.QueryServiceTestHelper{
+		GRPCQueryRouter: suite.App.GRPCQueryRouter(),
+		Ctx:             suite.Ctx,
 	}
 
-	s.TestAccs = CreateRandomAccounts(3)
+	suite.TestAccs = CreateRandomAccounts(3)
 }
 
 // CreateRandomAccounts is a function return a list of randomly generated AccAddresses
@@ -61,22 +61,22 @@ func CreateRandomAccounts(numAccts int) []sdk.AccAddress {
 }
 
 // FundAcc funds target address with specified amount.
-func (s *KeeperTestSuite) FundAcc(acc sdk.AccAddress, amounts sdk.Coins) {
-	err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, amounts)
-	s.NoError(err)
-	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, minttypes.ModuleName, acc, amounts)
-	s.NoError(err)
+func (suite *KeeperTestSuite) FundAcc(acc sdk.AccAddress, amounts sdk.Coins) {
+	err := suite.App.BankKeeper.MintCoins(suite.Ctx, minttypes.ModuleName, amounts)
+	suite.NoError(err)
+	err = suite.App.BankKeeper.SendCoinsFromModuleToAccount(suite.Ctx, minttypes.ModuleName, acc, amounts)
+	suite.NoError(err)
 }
 
-func (s *KeeperTestSuite) SetupTestForInitGenesis() {
+func (suite *KeeperTestSuite) SetupTestForInitGenesis() {
 	// Setting to True, leads to init genesis not running
-	s.App = app.Setup(s.T(), true)
-	s.Ctx = s.App.BaseApp.NewContext(true, tmtypes.Header{})
+	suite.App = app.Setup(suite.T(), true)
+	suite.Ctx = suite.App.BaseApp.NewContext(true, tmtypes.Header{})
 }
 
 // AssertEventEmitted asserts that ctx's event manager has emitted the given number of events
 // of the given type.
-func (s *KeeperTestSuite) AssertEventEmitted(ctx sdk.Context, eventTypeExpected string, numEventsExpected int) {
+func (suite *KeeperTestSuite) AssertEventEmitted(ctx sdk.Context, eventTypeExpected string, numEventsExpected int) {
 	allEvents := ctx.EventManager().Events()
 	// filter out other events
 	actualEvents := make([]sdk.Event, 0)
@@ -85,7 +85,7 @@ func (s *KeeperTestSuite) AssertEventEmitted(ctx sdk.Context, eventTypeExpected 
 			actualEvents = append(actualEvents, event)
 		}
 	}
-	s.Equal(numEventsExpected, len(actualEvents))
+	suite.Equal(numEventsExpected, len(actualEvents))
 }
 
 func TestKeeperTestSuite(t *testing.T) {


### PR DESCRIPTION
## 1. Summary
Fixes #280
<!-- What are you changing, removing, or adding in this review? -->

## 2.Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

The `app.AccountKeeper` [initialization](https://github.com/ingenuity-build/quicksilver/blob/d4a45f75c862e217ea7af75db68b9a294fe6831b/app/app.go#L401) was using `sdk.Bech32MainPrefix` which is `cosmos`.  

We just needed to change the value to `appconfig.Bech32PrefixAccAddr` from the `cmd/config` pkg.

Additionally, I added a call to `config.Seal()` which I believe should be used when running a full node through `main`.

## 4. How to test/use

Spin up a node and run the following query:

```
/cosmos/auth/v1beta1/bech32
```

## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 6. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 7. Future Work (optional)

- [ ] Verify that `config.Seal()` call is needed/non-breaking