### PR TITLE
chore: fix `go version` check in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ endif
 
 check_version:
 ifneq ($(shell expr $(GO_MINOR_VERSION) \>= 19), 1)
-	@echo "ERROR: Go version 1.19 is required for building Quicksilver. There are consensus breaking changes between binaries compiled with Go 1.18 and Go 1.19."
+	@echo "ERROR: Go version 1.19 or higher is required for building Quicksilver. There are consensus breaking changes between binaries compiled with Go 1.18 and Go 1.19."
 	@echo "Your go version is: $(shell go version)."
 	exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,9 @@ endif
 ###############################################################################
 
 check_version:
-ifneq ($(GO_MINOR_VERSION),19)
+ifneq ($(shell expr $(GO_MINOR_VERSION) \>= 19), 1)
 	@echo "ERROR: Go version 1.19 is required for building Quicksilver. There are consensus breaking changes between binaries compiled with Go 1.18 and Go 1.19."
+	@echo "Your go version is: $(shell go version)."
 	exit 1
 endif
 


### PR DESCRIPTION
## 1. Summary

The existing `check_version` target in our `Makefile` ONLY supported `go v1.19.x`. This PR changes the logic to check if the go version is greater than or equal to `v1.19`, allowing for `v1.20.x` and above to be used.

NOTE: 

Since we already are requiring `go 1.19` in our `go.mod` file, I'm not actually sure how necessary this check is.  All compilation  / testing / etc. will need to parse and check the `go.mod` file anyways.

## 2.Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## 4. How to test/use

Verify that build works with go `v1.19.x` and `v1.20.x` while `v1.18.x` and below are NOT supported.
## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 6. Limitations (optional)

Verify that there are no consensus breaking changes made from `1.19` to `1.20`.