### PR TITLE
fix: duplicated `mint` query names

### DIFF
--- a/x/claimsmanager/client/cli/query.go
+++ b/x/claimsmanager/client/cli/query.go
@@ -3,11 +3,10 @@ package cli
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
-	"github.com/ingenuity-build/quicksilver/x/mint/types"
-
-	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ingenuity-build/quicksilver/x/claimsmanager/types"
 )
 
 // GetQueryCmd returns the cli query commands for the claimsmanager module.

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
 	"github.com/ingenuity-build/quicksilver/x/mint/types"
-
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 )
 
 // GetQueryCmd returns the cli query commands for the minting module.
 func GetQueryCmd() *cobra.Command {
+	fmt.Println("A")
 	mintingQueryCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      "Querying commands for the minting module",
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
@@ -35,7 +35,7 @@ func GetQueryCmd() *cobra.Command {
 func GetCmdQueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
-		Short: "Query the current minting parameters",
+		Short: "Get the params for the x/mint module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -64,7 +64,7 @@ func GetCmdQueryParams() *cobra.Command {
 func GetCmdQueryEpochProvisions() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "epoch-provisions",
-		Short: "Query the current minting epoch provisions value",
+		Short: "Query the current x/mint epoch provisions value",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)

--- a/x/participationrewards/client/cli/query.go
+++ b/x/participationrewards/client/cli/query.go
@@ -3,11 +3,10 @@ package cli
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
-	"github.com/ingenuity-build/quicksilver/x/mint/types"
-
-	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/ingenuity-build/quicksilver/x/participationrewards/types"
 )
 
 // GetQueryCmd returns the cli query commands for the minting module.


### PR DESCRIPTION
## 1. Summary
Fixes #256

## 2.Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

`x/participationrewards` and `x/claimsmanager` were importing `minttypes.ModuleName` instead of their own names for the query commands.

## 4. How to test/use

```
quicksilverd q
```

## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?
