### PR TITLE
fix: remove log line

### DIFF
--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -13,7 +13,6 @@ import (
 
 // GetQueryCmd returns the cli query commands for the minting module.
 func GetQueryCmd() *cobra.Command {
-	fmt.Println("A")
 	mintingQueryCmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),


### PR DESCRIPTION
## 1. Summary
Remove an accidentally included `fmt.Println()` call.

## 2.Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

