### PR TITLE
fix: workflow `go` version

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '1.19.6'
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '1.19.6'
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '1.19.6'
 
       - name: Setup Golang caches
         uses: actions/cache@v3

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
   pull_request:
 permissions:


### PR DESCRIPTION
## 1. Summary

Fixes an issue where workflows were inadvertently running a `go` version greater than `1.19`.

## 2.Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

https://github.com/ingenuity-build/quicksilver/actions/runs/4297029940/jobs/7489495234 is an example of the workflow failing because `go` version was bumped to `1.20.x`.
