### PR TITLE
refactor: `interchainstaking/keeper`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -885,7 +885,7 @@ func (app *Quicksilver) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock
 		if !found {
 			panic("ERROR: unable to find expected stargaze-1 zone")
 		}
-		app.InterchainstakingKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+		app.InterchainstakingKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 	}
 
 	return app.mm.BeginBlock(ctx, req)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -161,7 +161,7 @@ func v010400rc6UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 				true,
 				false,
 				6)
-			err := icskeeper.HandleRegisterZoneProposal(ctx, app.InterchainstakingKeeper, regenProp)
+			err := app.InterchainstakingKeeper.HandleRegisterZoneProposal(ctx, regenProp)
 			if err != nil {
 				return nil, err
 			}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -91,12 +91,12 @@ func noOpHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 func v010400UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// upgrade zones
-		app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone icstypes.Zone) (stop bool) {
+		app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *icstypes.Zone) (stop bool) {
 			zone.DepositsEnabled = true
 			zone.ReturnToSender = false
 			zone.UnbondingEnabled = false
 			zone.Decimals = 6
-			app.InterchainstakingKeeper.SetZone(ctx, &zone)
+			app.InterchainstakingKeeper.SetZone(ctx, zone)
 			return false
 		})
 
@@ -191,7 +191,7 @@ func v010400rc6UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 		})
 
 		if isTestnet(ctx) || isDevnet(ctx) {
-			app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zoneInfo icstypes.Zone) (stop bool) {
+			app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zoneInfo *icstypes.Zone) (stop bool) {
 				app.InterchainstakingKeeper.OverrideRedemptionRateNoCap(ctx, zoneInfo)
 				return false
 			})
@@ -204,11 +204,11 @@ func v010400rc6UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 func v010400rc8UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// remove expired failed redelegation records
-		app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone icstypes.Zone) (stop bool) {
-			app.InterchainstakingKeeper.IterateAllDelegations(ctx, &zone, func(delegation icstypes.Delegation) (stop bool) {
+		app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *icstypes.Zone) (stop bool) {
+			app.InterchainstakingKeeper.IterateAllDelegations(ctx, zone, func(delegation icstypes.Delegation) (stop bool) {
 				if delegation.RedelegationEnd < 0 {
 					delegation.RedelegationEnd = 0
-					app.InterchainstakingKeeper.SetDelegation(ctx, &zone, delegation)
+					app.InterchainstakingKeeper.SetDelegation(ctx, zone, delegation)
 				}
 				return false
 			})

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -309,8 +309,8 @@ func (s *AppTestSuite) TestV010400rc8UpgradeHandler() {
 	zone, _ = app.InterchainstakingKeeper.GetZone(ctx, "uni-5")
 
 	var negRedelEndsBefore []icstypes.Delegation
-	app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone icstypes.Zone) (stop bool) {
-		app.InterchainstakingKeeper.IterateAllDelegations(ctx, &zone, func(delegation icstypes.Delegation) (stop bool) {
+	app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *icstypes.Zone) (stop bool) {
+		app.InterchainstakingKeeper.IterateAllDelegations(ctx, zone, func(delegation icstypes.Delegation) (stop bool) {
 			if delegation.RedelegationEnd < 0 {
 				negRedelEndsBefore = append(negRedelEndsBefore, delegation)
 			}
@@ -329,8 +329,8 @@ func (s *AppTestSuite) TestV010400rc8UpgradeHandler() {
 
 	var negRedelEndsAfter []icstypes.Delegation
 
-	app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone icstypes.Zone) (stop bool) {
-		app.InterchainstakingKeeper.IterateAllDelegations(ctx, &zone, func(delegation icstypes.Delegation) (stop bool) {
+	app.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *icstypes.Zone) (stop bool) {
+		app.InterchainstakingKeeper.IterateAllDelegations(ctx, zone, func(delegation icstypes.Delegation) (stop bool) {
 			if delegation.RedelegationEnd < 0 {
 				negRedelEndsAfter = append(negRedelEndsAfter, delegation)
 			}

--- a/x/airdrop/keeper/claim_handler.go
+++ b/x/airdrop/keeper/claim_handler.go
@@ -183,7 +183,7 @@ func (k Keeper) verifyZoneIntent(ctx sdk.Context, chainID string, address string
 		return fmt.Errorf("zone %s not found", chainID)
 	}
 
-	intent, ok := k.icsKeeper.GetIntent(ctx, zone, addr.String(), false)
+	intent, ok := k.icsKeeper.GetIntent(ctx, &zone, addr.String(), false)
 	if !ok || len(intent.Intents) == 0 {
 		return fmt.Errorf("intent not found or no intents set for %s", addr)
 	}
@@ -226,9 +226,9 @@ func (k Keeper) verifyGovernanceParticipation(ctx sdk.Context, address string) e
 func (k Keeper) verifyOsmosisLP(ctx sdk.Context, proofs []*cmtypes.Proof, cr types.ClaimRecord) error {
 	// get Osmosis zone
 	var osmoZone *icstypes.Zone
-	k.icsKeeper.IterateZones(ctx, func(_ int64, zone icstypes.Zone) (stop bool) {
+	k.icsKeeper.IterateZones(ctx, func(_ int64, zone *icstypes.Zone) (stop bool) {
 		if zone.AccountPrefix == "osmo" {
-			osmoZone = &zone
+			osmoZone = zone
 			return true
 		}
 		return false

--- a/x/airdrop/keeper/msg_server_test.go
+++ b/x/airdrop/keeper/msg_server_test.go
@@ -315,7 +315,7 @@ func (suite *KeeperTestSuite) Test_msgServer_Claim() {
 				}
 				appA.InterchainstakingKeeper.SetIntent(
 					suite.chainA.GetContext(),
-					zone,
+					&zone,
 					intent,
 					false,
 				)

--- a/x/interchainstaking/genesis.go
+++ b/x/interchainstaking/genesis.go
@@ -49,7 +49,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			panic("unable to find zone for delegation")
 		}
 		for _, delegatorIntent := range delegatorIntentsForZone.DelegationIntent {
-			k.SetIntent(ctx, zone, *delegatorIntent, false)
+			k.SetIntent(ctx, &zone, *delegatorIntent, false)
 		}
 	}
 
@@ -78,8 +78,8 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 
 func ExportDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegationsForZone {
 	delegationsForZones := make([]types.DelegationsForZone, 0)
-	k.IterateZones(ctx, func(_ int64, zoneInfo types.Zone) (stop bool) {
-		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zoneInfo.ChainId, Delegations: k.GetAllDelegationsAsPointer(ctx, &zoneInfo)})
+	k.IterateZones(ctx, func(_ int64, zoneInfo *types.Zone) (stop bool) {
+		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zoneInfo.ChainId, Delegations: k.GetAllDelegationsAsPointer(ctx, zoneInfo)})
 		return false
 	})
 	return delegationsForZones
@@ -87,8 +87,8 @@ func ExportDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.Delegati
 
 func ExportPerformanceDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegationsForZone {
 	delegationsForZones := make([]types.DelegationsForZone, 0)
-	k.IterateZones(ctx, func(_ int64, zoneInfo types.Zone) (stop bool) {
-		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zoneInfo.ChainId, Delegations: k.GetAllPerformanceDelegationsAsPointer(ctx, &zoneInfo)})
+	k.IterateZones(ctx, func(_ int64, zoneInfo *types.Zone) (stop bool) {
+		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zoneInfo.ChainId, Delegations: k.GetAllPerformanceDelegationsAsPointer(ctx, zoneInfo)})
 		return false
 	})
 	return delegationsForZones
@@ -96,7 +96,7 @@ func ExportPerformanceDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []typ
 
 func ExportDelegatorIntentsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegatorIntentsForZone {
 	delegatorIntentsForZones := make([]types.DelegatorIntentsForZone, 0)
-	k.IterateZones(ctx, func(_ int64, zoneInfo types.Zone) (stop bool) {
+	k.IterateZones(ctx, func(_ int64, zoneInfo *types.Zone) (stop bool) {
 		// export current epoch intents
 		delegatorIntentsForZones = append(delegatorIntentsForZones, types.DelegatorIntentsForZone{ChainId: zoneInfo.ChainId, DelegationIntent: k.AllIntentsAsPointer(ctx, zoneInfo, false), Snapshot: false})
 		// export last epoch intents

--- a/x/interchainstaking/handler.go
+++ b/x/interchainstaking/handler.go
@@ -36,9 +36,9 @@ func NewProposalHandler(k keeper.Keeper) govv1beta1.Handler {
 	return func(ctx sdk.Context, content govv1beta1.Content) error {
 		switch c := content.(type) {
 		case *types.RegisterZoneProposal:
-			return keeper.HandleRegisterZoneProposal(ctx, k, c)
+			return k.HandleRegisterZoneProposal(ctx, c)
 		case *types.UpdateZoneProposal:
-			return keeper.HandleUpdateZoneProposal(ctx, k, c)
+			return k.HandleUpdateZoneProposal(ctx, c)
 
 		default:
 			return sdkioerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized interchainstaking proposal content type: %T", c)

--- a/x/interchainstaking/keeper/abci.go
+++ b/x/interchainstaking/keeper/abci.go
@@ -17,7 +17,7 @@ import (
 type zoneItrFn func(index int64, zoneInfo *types.Zone) (stop bool)
 
 // BeginBlocker of interchainstaking module
-func (k Keeper) BeginBlocker(ctx sdk.Context) {
+func (k *Keeper) BeginBlocker(ctx sdk.Context) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 
 	if ctx.BlockHeight()%30 == 0 {

--- a/x/interchainstaking/keeper/abci.go
+++ b/x/interchainstaking/keeper/abci.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmtypes "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types"
@@ -11,7 +14,7 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-type zoneItrFn func(index int64, zoneInfo types.Zone) (stop bool)
+type zoneItrFn func(index int64, zoneInfo *types.Zone) (stop bool)
 
 // BeginBlocker of interchainstaking module
 func (k Keeper) BeginBlocker(ctx sdk.Context) {
@@ -22,7 +25,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 			k.Logger(ctx).Error("error in GCCompletedRedelegations", "error", err)
 		}
 	}
-	k.IterateZones(ctx, func(index int64, zone types.Zone) (stop bool) {
+	k.IterateZones(ctx, func(index int64, zone *types.Zone) (stop bool) {
 		if ctx.BlockHeight()%30 == 0 {
 			// for the tasks below, we cannot panic in begin blocker; as this will crash the chain.
 			// and as failing here is not terminal we panicking is not necessary, but we should log
@@ -30,13 +33,13 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 			// tasks below.
 			// commenting this out until we can revisit. in it's current state it causes more issues than it fixes.
 
-			if err := k.EnsureWithdrawalAddresses(ctx, &zone); err != nil {
+			if err := k.EnsureWithdrawalAddresses(ctx, zone); err != nil {
 				k.Logger(ctx).Error("error in EnsureWithdrawalAddresses", "error", err)
 			}
-			if err := k.HandleMaturedUnbondings(ctx, &zone); err != nil {
+			if err := k.HandleMaturedUnbondings(ctx, zone); err != nil {
 				k.Logger(ctx).Error("error in HandleMaturedUnbondings", "error", err)
 			}
-			if err := k.GCCompletedUnbondings(ctx, &zone); err != nil {
+			if err := k.GCCompletedUnbondings(ctx, zone); err != nil {
 				k.Logger(ctx).Error("error in GCCompletedUnbondings", "error", err)
 			}
 
@@ -50,7 +53,9 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 					if len(zone.IbcNextValidatorsHash) == 0 || !bytes.Equal(zone.IbcNextValidatorsHash, tmConsState.NextValidatorsHash.Bytes()) {
 						k.Logger(ctx).Info("IBC ValSet has changed; requerying valset")
 						// trigger valset update.
-						err := k.EmitValsetRequery(ctx, zone.ConnectionId, zone.ChainId)
+						period := int64(k.GetParam(ctx, types.KeyValidatorSetInterval))
+						query := stakingTypes.QueryValidatorsRequest{}
+						err := k.EmitValSetQuery(ctx, zone, query, sdkmath.NewInt(period))
 						if err != nil {
 							k.Logger(ctx).Error("unable to trigger valset update query", "error", err)
 							// failing to emit the valset update is not terminal but constitutes
@@ -58,7 +63,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 							// we should investigate.
 						}
 						zone.IbcNextValidatorsHash = tmConsState.NextValidatorsHash.Bytes()
-						k.SetZone(ctx, &zone)
+						k.SetZone(ctx, zone)
 					}
 				}
 			}

--- a/x/interchainstaking/keeper/callbacks.go
+++ b/x/interchainstaking/keeper/callbacks.go
@@ -79,7 +79,7 @@ func ValsetCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query
 	if !found {
 		return fmt.Errorf("no registered zone for chain id: %s", query.GetChainId())
 	}
-	return k.SetValidatorsForZone(ctx, zone, args, query.Request)
+	return k.SetValidatorsForZone(ctx, &zone, args, query.Request)
 }
 
 func ValidatorCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {
@@ -87,7 +87,7 @@ func ValidatorCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Qu
 	if !found {
 		return fmt.Errorf("no registered zone for chain id: %s", query.GetChainId())
 	}
-	return SetValidatorForZone(&k, ctx, zone, args)
+	return k.SetValidatorForZone(ctx, &zone, args)
 }
 
 func RewardsCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {
@@ -413,7 +413,7 @@ func DepositTx(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) err
 		return fmt.Errorf("unable to validate proof: %w", err)
 	}
 
-	return k.HandleReceiptTransaction(ctx, res.GetTxResponse(), res.GetTx(), zone)
+	return k.HandleReceiptTransaction(ctx, res.GetTxResponse(), res.GetTx(), &zone)
 }
 
 // AccountBalanceCallback is a callback handler for Balance queries.
@@ -456,7 +456,7 @@ func AccountBalanceCallback(k Keeper, ctx sdk.Context, args []byte, query icqtyp
 		return err
 	}
 
-	return SetAccountBalanceForDenom(k, ctx, zone, address, coin)
+	return SetAccountBalanceForDenom(k, ctx, &zone, address, coin)
 }
 
 func AllBalancesCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {

--- a/x/interchainstaking/keeper/callbacks.go
+++ b/x/interchainstaking/keeper/callbacks.go
@@ -231,7 +231,7 @@ func DepositIntervalCallback(k *Keeper, ctx sdk.Context, args []byte, query icqt
 	for _, txn := range txs.TxResponses {
 		req := tx.GetTxRequest{Hash: txn.TxHash}
 		hashBytes := k.cdc.MustMarshal(&req)
-		_, found = k.GetReceipt(ctx, GetReceiptKey(zone.ChainId, txn.TxHash))
+		_, found = k.GetReceipt(ctx, types.GetReceiptKey(zone.ChainId, txn.TxHash))
 		if found {
 			k.Logger(ctx).Debug("Found previously handled tx. Ignoring.", "txhash", txn.TxHash)
 			continue
@@ -367,7 +367,7 @@ func DepositTx(k *Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) er
 		return err
 	}
 
-	_, found = k.GetReceipt(ctx, GetReceiptKey(zone.ChainId, res.GetTxResponse().TxHash))
+	_, found = k.GetReceipt(ctx, types.GetReceiptKey(zone.ChainId, res.GetTxResponse().TxHash))
 	if found {
 		k.Logger(ctx).Debug("Found previously handled tx. Ignoring.", "txhash", res.GetTxResponse().TxHash)
 		return nil

--- a/x/interchainstaking/keeper/callbacks.go
+++ b/x/interchainstaking/keeper/callbacks.go
@@ -79,7 +79,7 @@ func ValsetCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query
 	if !found {
 		return fmt.Errorf("no registered zone for chain id: %s", query.GetChainId())
 	}
-	return SetValidatorsForZone(&k, ctx, zone, args, query.Request)
+	return k.SetValidatorsForZone(ctx, zone, args, query.Request)
 }
 
 func ValidatorCallback(k Keeper, ctx sdk.Context, args []byte, query icqtypes.Query) error {

--- a/x/interchainstaking/keeper/callbacks_test.go
+++ b/x/interchainstaking/keeper/callbacks_test.go
@@ -248,7 +248,7 @@ func (s *KeeperTestSuite) TestHandleValsetCallback() {
 			bz, err := app.AppCodec().Marshal(&query)
 			s.Require().NoError(err)
 
-			err = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
+			err = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
 			s.Require().NoError(err)
 			// valset callback doesn't actually update validators, but does emit icq callbacks.
 			test.checks(s.Require(), ctx, app, chainBVals)
@@ -269,7 +269,7 @@ func (s *KeeperTestSuite) TestHandleValsetCallbackBadChain() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		s.Require().Error(err)
 	})
@@ -288,7 +288,7 @@ func (s *KeeperTestSuite) TestHandleValsetCallbackNilValset() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
+		err = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		s.Require().Error(err)
 	})
@@ -307,7 +307,7 @@ func (s *KeeperTestSuite) TestHandleValsetCallbackInvalidResponse() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
+		err = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		s.Require().Error(err)
 	})
@@ -347,7 +347,7 @@ func (s *KeeperTestSuite) TestHandleValidatorCallbackBadChain() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.ValidatorCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.ValidatorCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		s.Require().Error(err)
 	})
@@ -364,7 +364,7 @@ func (s *KeeperTestSuite) TestHandleValidatorCallbackNilValue() {
 
 		bz := []byte{}
 
-		err := keeper.ValidatorCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
+		err := keeper.ValidatorCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		s.Require().Error(err)
 	})
@@ -421,7 +421,7 @@ func (s *KeeperTestSuite) TestHandleValidatorCallback() {
 			bz, err := app.AppCodec().Marshal(&test.validator)
 			s.Require().NoError(err)
 
-			err = keeper.ValidatorCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
+			err = keeper.ValidatorCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
 			s.Require().NoError(err)
 
 			zone, found := app.InterchainstakingKeeper.GetZone(ctx, zone.ChainId)
@@ -617,7 +617,7 @@ func (s *KeeperTestSuite) TestHandleValidatorCallbackJailedWithSlashing() {
 			bz, err := app.AppCodec().Marshal(test.validator(zone))
 			s.Require().NoError(err)
 
-			err = keeper.ValidatorCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
+			err = keeper.ValidatorCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
 			s.Require().NoError(err)
 
 			wr, found := app.InterchainstakingKeeper.GetWithdrawalRecord(ctx, s.chainB.ChainID, test.withdrawal(zone).Txhash, test.withdrawal(zone).Status)
@@ -700,7 +700,7 @@ func (s *KeeperTestSuite) TestHandleRewardsCallbackBadChain() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.RewardsCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.RewardsCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		s.Require().Error(err)
 	})
@@ -719,7 +719,7 @@ func (s *KeeperTestSuite) TestHandleRewardsEmptyRequestCallback() {
 		bz, err := app.AppCodec().Marshal(&query)
 		s.Require().NoError(err)
 
-		err = keeper.RewardsCallback(app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
+		err = keeper.RewardsCallback(&app.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: s.chainB.ChainID})
 		// this should fail because the waitgroup becomes negative.
 		s.Require().Errorf(err, "attempted to unmarshal zero length byte slice (2)")
 	})
@@ -755,7 +755,7 @@ func (s *KeeperTestSuite) TestHandleRewardsCallbackNonDelegator() {
 
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
-		err = keeper.RewardsCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		//
 		s.Require().Errorf(err, "failed attempting to withdraw rewards from non-delegation account")
 	})
@@ -784,7 +784,7 @@ func (s *KeeperTestSuite) TestHandleRewardsCallbackEmptyResponse() {
 
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
-		err = keeper.RewardsCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		//
 		s.Require().NoError(err)
 	})
@@ -818,7 +818,7 @@ func (s *KeeperTestSuite) TestHandleValideRewardsCallback() {
 
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
-		err = keeper.RewardsCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		//
 		s.Require().NoError(err)
 	})
@@ -845,7 +845,7 @@ func (s *KeeperTestSuite) TestAllBalancesCallback() {
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		s.Require().NoError(err)
 
 		// refetch zone
@@ -895,7 +895,7 @@ func (s *KeeperTestSuite) TestAllBalancesCallbackWithExistingWg() {
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		s.Require().NoError(err)
 
 		// refetch zone
@@ -948,7 +948,7 @@ func (s *KeeperTestSuite) TestAllBalancesCallbackExistingBalanceNowNil() {
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		s.Require().NoError(err)
 
 		// refetch zone
@@ -996,7 +996,7 @@ func (s *KeeperTestSuite) TestAllBalancesCallbackExistingBalanceNowNil() {
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		s.Require().NoError(err)
 
 		// refetch zone
@@ -1044,7 +1044,7 @@ func (s *KeeperTestSuite) TestAllBalancesCallbackMulti() {
 		respbz, err := app.AppCodec().Marshal(&response)
 		s.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 		s.Require().NoError(err)
 
 		// refetch zone
@@ -1096,7 +1096,7 @@ func (s *KeeperTestSuite) TestAccountBalanceCallback() {
 			s.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("qck")...)
 
-			err = keeper.AccountBalanceCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
 			s.Require().NoError(err)
 		}
 	})
@@ -1126,7 +1126,7 @@ func (s *KeeperTestSuite) TestAccountBalance046Callback() {
 			s.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("qck")...)
 
-			err = keeper.AccountBalanceCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
 			s.Require().NoError(err)
 		}
 	})
@@ -1155,7 +1155,7 @@ func (s *KeeperTestSuite) TestAccountBalanceCallbackMismatch() {
 			s.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("stake")...)
 
-			err = keeper.AccountBalanceCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
 			s.Require().ErrorContains(err, "received coin denom qck does not match requested denom stake")
 		}
 	})
@@ -1184,7 +1184,7 @@ func (s *KeeperTestSuite) TestAccountBalanceCallbackNil() {
 			s.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("stake")...)
 
-			err = keeper.AccountBalanceCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
 			s.Require().NoError(err)
 		}
 	})
@@ -1203,7 +1203,7 @@ func TestValsetCallbackNilValidatorReqPagination(t *testing.T) {
 	ctx := s.chainA.GetContext()
 
 	data := []byte("\x12\"\n 00000000000000000000000000000000")
-	_ = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
+	_ = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
 }
 
 func TestDelegationsCallbackAllPresentNoChange(t *testing.T) {
@@ -1240,7 +1240,7 @@ func TestDelegationsCallbackAllPresentNoChange(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 
 	s.Require().NoError(err)
 
@@ -1289,7 +1289,7 @@ func TestDelegationsCallbackAllPresentOneChange(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 
 	s.Require().NoError(err)
 
@@ -1337,7 +1337,7 @@ func TestDelegationsCallbackOneMissing(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 
 	s.Require().NoError(err)
 
@@ -1387,7 +1387,7 @@ func TestDelegationsCallbackOneAdditional(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 
 	s.Require().NoError(err)
 
@@ -1435,7 +1435,7 @@ func TestDelegationCallbackNew(t *testing.T) {
 	s.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 	s.Require().NoError(err)
 
 	s.Require().Equal(4, len(app.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1474,7 +1474,7 @@ func TestDelegationCallbackUpdate(t *testing.T) {
 	s.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 	s.Require().NoError(err)
 
 	s.Require().Equal(3, len(app.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1513,7 +1513,7 @@ func TestDelegationCallbackNoOp(t *testing.T) {
 	s.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 	s.Require().NoError(err)
 
 	s.Require().Equal(3, len(app.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1552,7 +1552,7 @@ func TestDelegationCallbackRemove(t *testing.T) {
 	s.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID, Request: bz})
 	s.Require().NoError(err)
 
 	delegationRequests := 0
@@ -1580,7 +1580,7 @@ func TestDepositIntervalCallback(t *testing.T) {
 	app.InterchainQueryKeeper.IBCKeeper.Codec().MustUnmarshal(data, &res)
 	s.Require().NoError(err)
 
-	err = keeper.DepositIntervalCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
+	err = keeper.DepositIntervalCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
 	s.Require().NoError(err)
 	txQueryCount := 0
 	for _, query := range app.InterchainQueryKeeper.AllQueries(ctx) {
@@ -1622,7 +1622,7 @@ func TestDepositIntervalCallbackWithExistingTxs(t *testing.T) {
 	txrC := res.TxResponses[2]
 	app.InterchainstakingKeeper.SetReceipt(ctx, icstypes.Receipt{ChainId: s.chainB.ChainID, Sender: msgC.FromAddress, Txhash: txrC.TxHash, Amount: msgC.Amount})
 
-	err = keeper.DepositIntervalCallback(app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
+	err = keeper.DepositIntervalCallback(&app.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: s.chainB.ChainID})
 	s.Require().NoError(err)
 	txQueryCount := 0
 	for _, query := range app.InterchainQueryKeeper.AllQueries(ctx) {

--- a/x/interchainstaking/keeper/delegation.go
+++ b/x/interchainstaking/keeper/delegation.go
@@ -199,57 +199,11 @@ func (k *Keeper) PrepareDelegationMessagesForShares(ctx sdk.Context, zone *types
 	return msgs
 }
 
-func (k Keeper) DeterminePlanForDelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) map[string]sdkmath.Int {
+func (k *Keeper) DeterminePlanForDelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) map[string]sdkmath.Int {
 	currentAllocations, currentSum, _ := k.GetDelegationMap(ctx, zone)
 	targetAllocations := zone.GetAggregateIntentOrDefault()
-	allocations := DetermineAllocationsForDelegation(currentAllocations, currentSum, targetAllocations, amount)
+	allocations := types.DetermineAllocationsForDelegation(currentAllocations, currentSum, targetAllocations, amount)
 	return allocations
-}
-
-func DetermineAllocationsForDelegation(currentAllocations map[string]sdkmath.Int, currentSum sdkmath.Int, targetAllocations types.ValidatorIntents, amount sdk.Coins) map[string]sdkmath.Int {
-	input := amount[0].Amount
-	deltas := types.CalculateDeltas(currentAllocations, currentSum, targetAllocations)
-	minValue := types.MinDeltas(deltas)
-	sum := sdk.ZeroInt()
-
-	// raise all deltas such that the minimum value is zero.
-	for idx := range deltas {
-		deltas[idx].Weight = deltas[idx].Weight.Add(sdk.NewDecFromInt(minValue.Abs()))
-		sum = sum.Add(deltas[idx].Weight.TruncateInt())
-	}
-
-	// unequalSplit is the portion of input that should be distributed in attempt to make targets == 0
-	unequalSplit := sdk.MinInt(sum, input)
-
-	if !unequalSplit.IsZero() {
-		for idx := range deltas {
-			deltas[idx].Weight = deltas[idx].Weight.QuoInt(sum).MulInt(unequalSplit)
-		}
-	}
-
-	// equalSplit is the portion of input that should be distributed equally across all validators, once targets are zero.
-	equalSplit := sdk.NewDecFromInt(input.Sub(unequalSplit))
-
-	if !equalSplit.IsZero() {
-		each := equalSplit.Quo(sdk.NewDec(int64(len(deltas))))
-		for idx := range deltas {
-			deltas[idx].Weight = deltas[idx].Weight.Add(each)
-		}
-	}
-
-	// dust is the portion of the input that was truncated in previous calculations; add this to the first validator in the list,
-	// once sorted alphabetically. This will always be a small amount, and will count toward the delta calculations on the next run.
-
-	outSum := sdk.ZeroInt()
-	outWeights := make(map[string]sdkmath.Int)
-	for _, delta := range deltas {
-		outWeights[delta.ValoperAddress] = delta.Weight.TruncateInt()
-		outSum = outSum.Add(delta.Weight.TruncateInt())
-	}
-	dust := input.Sub(outSum)
-	outWeights[deltas[0].ValoperAddress] = outWeights[deltas[0].ValoperAddress].Add(dust)
-
-	return outWeights
 }
 
 func (k *Keeper) WithdrawDelegationRewardsForResponse(ctx sdk.Context, zone *types.Zone, delegator string, response []byte) error {

--- a/x/interchainstaking/keeper/delegation_test.go
+++ b/x/interchainstaking/keeper/delegation_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	cosmosmath "cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ingenuity-build/quicksilver/utils"
 	icskeeper "github.com/ingenuity-build/quicksilver/x/interchainstaking/keeper"
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
-	"github.com/stretchr/testify/require"
 )
 
 func (suite *KeeperTestSuite) TestKeeper_DelegationStore() {
@@ -39,7 +40,7 @@ func (suite *KeeperTestSuite) TestKeeper_DelegationStore() {
 	suite.Require().True(found)
 	suite.Require().Equal(uint64(0), updateDelegation.Amount.Amount.Uint64())
 
-	updateDelegation.Amount.Amount = cosmosmath.NewInt(10000)
+	updateDelegation.Amount.Amount = sdkmath.NewInt(10000)
 	icsKeeper.SetPerformanceDelegation(ctx, &zone, updateDelegation)
 
 	updatedDelegation, found := icsKeeper.GetPerformanceDelegation(ctx, &zone, zoneValidatorAddresses[0])
@@ -107,14 +108,14 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 	val4 := utils.GenerateValAddressForTest()
 
 	tc := []struct {
-		current  map[string]cosmosmath.Int
+		current  map[string]sdkmath.Int
 		target   types.ValidatorIntents
 		inAmount sdk.Coins
-		expected map[string]cosmosmath.Int
-		dust     cosmosmath.Int
+		expected map[string]sdkmath.Int
+		dust     sdkmath.Int
 	}{
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(350000),
 				val2.String(): sdk.NewInt(650000),
 				val3.String(): sdk.NewInt(75000),
@@ -125,14 +126,14 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(7, 2)},
 			},
 			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(50000))),
-			expected: map[string]cosmosmath.Int{
+			expected: map[string]sdkmath.Int{
 				val1.String(): sdk.ZeroInt(),
 				val2.String(): sdk.NewInt(33182),
 				val3.String(): sdk.NewInt(16818),
 			},
 		},
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(52),
 				val2.String(): sdk.NewInt(24),
 				val3.String(): sdk.NewInt(20),
@@ -145,7 +146,7 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
 			},
 			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(20))),
-			expected: map[string]cosmosmath.Int{
+			expected: map[string]sdkmath.Int{
 				val4.String(): sdk.NewInt(11),
 				val3.String(): sdk.ZeroInt(),
 				val2.String(): sdk.NewInt(6),
@@ -153,7 +154,7 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 			},
 		},
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(52),
 				val2.String(): sdk.NewInt(24),
 				val3.String(): sdk.NewInt(20),
@@ -166,7 +167,7 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
 			},
 			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(50))),
-			expected: map[string]cosmosmath.Int{
+			expected: map[string]sdkmath.Int{
 				val4.String(): sdk.NewInt(20),
 				val2.String(): sdk.NewInt(13),
 				val1.String(): sdk.NewInt(10),
@@ -176,7 +177,7 @@ func TestDetermineAllocationsForDelegation(t *testing.T) {
 	}
 
 	for caseNumber, val := range tc {
-		sum := cosmosmath.ZeroInt()
+		sum := sdkmath.ZeroInt()
 		for _, amount := range val.current {
 			sum = sum.Add(amount)
 		}
@@ -340,12 +341,12 @@ func TestCalculateDeltas(t *testing.T) {
 	}}
 
 	tc := []struct {
-		current  map[string]cosmosmath.Int
+		current  map[string]sdkmath.Int
 		target   types.ValidatorIntents
 		expected types.ValidatorIntents
 	}{
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(350000),
 				val2.String(): sdk.NewInt(650000),
 				val3.String(): sdk.NewInt(75000),
@@ -362,7 +363,7 @@ func TestCalculateDeltas(t *testing.T) {
 			},
 		},
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(53),
 				val2.String(): sdk.NewInt(26),
 				val3.String(): sdk.NewInt(14),
@@ -382,7 +383,7 @@ func TestCalculateDeltas(t *testing.T) {
 			},
 		},
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(30),
 				val2.String(): sdk.NewInt(30),
 				val3.String(): sdk.NewInt(60),
@@ -403,7 +404,7 @@ func TestCalculateDeltas(t *testing.T) {
 		},
 		// default intent -- all equal
 		{
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(15),
 				val2.String(): sdk.NewInt(5),
 				val3.String(): sdk.NewInt(20),
@@ -419,7 +420,7 @@ func TestCalculateDeltas(t *testing.T) {
 		},
 		{
 			// GetAggregateIntentOrDefault will preclude val4 on account on high commission.
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
@@ -436,11 +437,11 @@ func TestCalculateDeltas(t *testing.T) {
 	}
 
 	for caseNumber, val := range tc {
-		sum := cosmosmath.ZeroInt()
+		sum := sdkmath.ZeroInt()
 		for _, amount := range val.current {
 			sum = sum.Add(amount)
 		}
-		deltas := icskeeper.CalculateDeltas(val.current, sum, val.target)
+		deltas := types.CalculateDeltas(val.current, sum, val.target)
 		require.Equal(t, len(val.expected), len(deltas), fmt.Sprintf("expected %d RebalanceTargets in case %d, got %d", len(val.expected), caseNumber, len(deltas)))
 		for idx, expected := range val.expected {
 			require.Equal(t, expected, deltas[idx], fmt.Sprintf("case %d, idx %d: Expected %v, got %v", caseNumber, idx, expected, deltas[idx]))
@@ -474,16 +475,16 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 
 	tc := []struct {
 		name          string
-		current       map[string]cosmosmath.Int
+		current       map[string]sdkmath.Int
 		locked        map[string]bool
 		target        types.ValidatorIntents
-		expected      []icskeeper.RebalanceTarget
-		dust          cosmosmath.Int
+		expected      []types.RebalanceTarget
+		dust          sdkmath.Int
 		redelegations []types.RedelegationRecord
 	}{
 		{
 			name: "case 1",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(350000),
 				val2.String(): sdk.NewInt(650000),
 				val3.String(): sdk.NewInt(75000),
@@ -493,14 +494,14 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 				{ValoperAddress: val2.String(), Weight: sdk.NewDecWithPrec(63, 2)},
 				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(7, 2)},
 			},
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(27250), Source: val1.String(), Target: val2.String()},
-				{Amount: cosmosmath.NewInt(250), Source: val1.String(), Target: val3.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(27250), Source: val1.String(), Target: val2.String()},
+				{Amount: sdkmath.NewInt(250), Source: val1.String(), Target: val3.String()},
 			},
 		},
 		{
 			name: "case 2",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(56),
 				val2.String(): sdk.NewInt(24),
 				val3.String(): sdk.NewInt(14),
@@ -512,15 +513,15 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(12, 2)},
 				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
 			},
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(4), Source: val1.String(), Target: val4.String()},
-				{Amount: cosmosmath.NewInt(3), Source: val1.String(), Target: val2.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(4), Source: val1.String(), Target: val4.String()},
+				{Amount: sdkmath.NewInt(3), Source: val1.String(), Target: val2.String()},
 			},
 			redelegations: []types.RedelegationRecord{},
 		},
 		{
 			name: "case 3",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(30),
 				val2.String(): sdk.NewInt(30),
 				val3.String(): sdk.NewInt(60),
@@ -532,63 +533,63 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(15, 2)},
 				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
 			},
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(42), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(42), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val2.String()},
 			},
 			redelegations: []types.RedelegationRecord{},
 		},
 		// default intent -- all equal
 		{
 			name: "case 4 - default intent, all equal",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(15),
 				val2.String(): sdk.NewInt(5),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(14), Source: val4.String(), Target: val2.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(14), Source: val4.String(), Target: val2.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val1.String()},
-				//{Amount: cosmosmath.NewInt(5), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val1.String()},
+				//{Amount: sdkmath.NewInt(5), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{},
 		},
 		//
 		{
 			name: "case 5 - default intent with val4 high commission; truncate rebalance to 50% of tvl",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(14), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(14), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(21), Source: val4.String(), Target: val2.String()},
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(21), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{},
 		},
 		{
 			name: "case 6 - includes redelegation, no impact",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(14), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(14), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(21), Source: val4.String(), Target: val2.String()},
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(21), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{
 				{ChainId: "test-1", EpochNumber: 1, Source: val2.String(), Destination: val4.String(), Amount: 30, CompletionTime: time.Now().Add(time.Hour)},
@@ -596,18 +597,18 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 		},
 		{
 			name: "case 7 - includes redelegation, truncated delegation",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(21), Source: val4.String(), Target: val2.String()},
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(21), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{
 				{ChainId: "test-1", EpochNumber: 1, Source: val2.String(), Destination: val4.String(), Amount: 50, CompletionTime: time.Now().Add(time.Hour)},
@@ -615,18 +616,18 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 		},
 		{
 			name: "case 8 - includes redelegation, truncated delegation",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(21), Source: val4.String(), Target: val2.String()},
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(21), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{
 				{ChainId: "test-1", EpochNumber: 1, Source: val2.String(), Destination: val4.String(), Amount: 50, CompletionTime: time.Now().Add(time.Hour)},
@@ -634,18 +635,18 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 		},
 		{
 			name: "case 9 - includes redelegation, truncated delegation overflow",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(2),
 				val2.String(): sdk.NewInt(8),
 				val3.String(): sdk.NewInt(30),
 				val4.String(): sdk.NewInt(60),
 			},
 			target: zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(4), Source: val3.String(), Target: val1.String()}, // joe: I would expect this to be included...
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val3.String(), Target: val1.String()}, // joe: I would expect this to be included...
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{
 				{ChainId: "test-1", EpochNumber: 1, Source: val2.String(), Destination: val4.String(), Amount: 50, CompletionTime: time.Now().Add(time.Hour)},
@@ -653,18 +654,18 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 		},
 		{
 			name: "case 10 - includes redelegation, zero delegation",
-			current: map[string]cosmosmath.Int{
+			current: map[string]sdkmath.Int{
 				val1.String(): sdk.NewInt(8),
 				val2.String(): sdk.NewInt(12),
 				val3.String(): sdk.NewInt(20),
 				val4.String(): sdk.NewInt(60),
 			},
 			target:   zone2.GetAggregateIntentOrDefault(),
-			expected: []icskeeper.RebalanceTarget{
-				//{Amount: cosmosmath.NewInt(10), Source: val4.String(), Target: val1.String()},
+			expected: []types.RebalanceTarget{
+				//{Amount: sdkmath.NewInt(10), Source: val4.String(), Target: val1.String()},
 				// below values _would_ applied, if we weren't limited by a max of total/7
-				//{Amount: cosmosmath.NewInt(21), Source: val4.String(), Target: val2.String()},
-				//{Amount: cosmosmath.NewInt(4), Source: val4.String(), Target: val3.String()},
+				//{Amount: sdkmath.NewInt(21), Source: val4.String(), Target: val2.String()},
+				//{Amount: sdkmath.NewInt(4), Source: val4.String(), Target: val3.String()},
 			},
 			redelegations: []types.RedelegationRecord{
 				{ChainId: "test-1", EpochNumber: 1, Source: val2.String(), Destination: val4.String(), Amount: 60, CompletionTime: time.Now().Add(time.Hour)},
@@ -673,11 +674,11 @@ func TestDetermineAllocationsForRebalance(t *testing.T) {
 	}
 
 	for _, val := range tc {
-		sum := cosmosmath.ZeroInt()
+		sum := sdkmath.ZeroInt()
 		for _, amount := range val.current {
 			sum = sum.Add(amount)
 		}
-		allocations := icskeeper.DetermineAllocationsForRebalancing(val.current, val.locked, sum, val.target, val.redelegations, nil)
+		allocations := types.DetermineAllocationsForRebalancing(val.current, val.locked, sum, val.target, val.redelegations, nil)
 		require.Equal(t, len(val.expected), len(allocations), fmt.Sprintf("expected %d RebalanceTargets in '%s', got %d", len(val.expected), val.name, len(allocations)))
 		for idx, rebalance := range val.expected {
 			require.Equal(t, rebalance, allocations[idx], fmt.Sprintf("%s, idx %d: Expected %v, got %v", val.name, idx, rebalance, allocations[idx]))

--- a/x/interchainstaking/keeper/fuzz_test.go
+++ b/x/interchainstaking/keeper/fuzz_test.go
@@ -297,7 +297,7 @@ func (s *FuzzingTestSuite) FuzzAccountBalanceCallback(t *testing.T, respbz []byt
 		s.Require().NoError(err)
 		data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("stake")...)
 
-		_ = keeper.AccountBalanceCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
+		_ = keeper.AccountBalanceCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: data})
 	}
 }
 
@@ -317,7 +317,7 @@ func (s *FuzzingTestSuite) FuzzDelegationsCallback(t *testing.T, respbz []byte) 
 	reqbz, err := app.AppCodec().Marshal(&query)
 	s.Require().NoError(err)
 
-	_ = keeper.DelegationsCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+	_ = keeper.DelegationsCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 }
 
 func (s *FuzzingTestSuite) FuzzAllBalancesCallback(t *testing.T, respbz []byte) {
@@ -337,7 +337,7 @@ func (s *FuzzingTestSuite) FuzzAllBalancesCallback(t *testing.T, respbz []byte) 
 	reqbz, err := app.AppCodec().Marshal(&query)
 	s.Require().NoError(err)
 
-	err = keeper.AllBalancesCallback(app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
+	err = keeper.AllBalancesCallback(&app.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: s.chainB.ChainID, Request: reqbz})
 	s.Require().NoError(err)
 }
 
@@ -346,5 +346,5 @@ func (s *FuzzingTestSuite) FuzzValsetCallback(t *testing.T, args []byte) {
 	app.InterchainstakingKeeper.CallbackHandler().RegisterCallbacks()
 	ctx := s.chainA.GetContext()
 
-	_ = keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, args, icqtypes.Query{ChainId: s.chainB.ChainID})
+	_ = keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, args, icqtypes.Query{ChainId: s.chainB.ChainID})
 }

--- a/x/interchainstaking/keeper/grpc_query.go
+++ b/x/interchainstaking/keeper/grpc_query.go
@@ -103,7 +103,7 @@ func (k Keeper) DelegatorIntent(c context.Context, req *types.QueryDelegatorInte
 
 	// we can ignore bool (found) as it always returns true
 	// - see comment in GetIntent
-	intent, _ := k.GetIntent(ctx, zone, req.DelegatorAddress, false)
+	intent, _ := k.GetIntent(ctx, &zone, req.DelegatorAddress, false)
 
 	return &types.QueryDelegatorIntentResponse{Intent: &intent}, nil
 }

--- a/x/interchainstaking/keeper/grpc_query.go
+++ b/x/interchainstaking/keeper/grpc_query.go
@@ -13,10 +13,10 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = &Keeper{}
 
 // Zones returns information about registered zones.
-func (k Keeper) Zones(c context.Context, req *types.QueryZonesInfoRequest) (*types.QueryZonesInfoResponse, error) {
+func (k *Keeper) Zones(c context.Context, req *types.QueryZonesInfoRequest) (*types.QueryZonesInfoResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -47,8 +47,8 @@ func (k Keeper) Zones(c context.Context, req *types.QueryZonesInfoRequest) (*typ
 	}, nil
 }
 
-// Zones returns information about registered zones.
-func (k Keeper) Zone(c context.Context, req *types.QueryZoneInfoRequest) (*types.QueryZoneInfoResponse, error) {
+// Zone returns information about registered zones.
+func (k *Keeper) Zone(c context.Context, req *types.QueryZoneInfoRequest) (*types.QueryZoneInfoResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -67,7 +67,7 @@ func (k Keeper) Zone(c context.Context, req *types.QueryZoneInfoRequest) (*types
 }
 
 // DepositAccount returns the deposit account address for the given zone.
-func (k Keeper) DepositAccount(c context.Context, req *types.QueryDepositAccountForChainRequest) (*types.QueryDepositAccountForChainResponse, error) {
+func (k *Keeper) DepositAccount(c context.Context, req *types.QueryDepositAccountForChainRequest) (*types.QueryDepositAccountForChainResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -89,7 +89,7 @@ func (k Keeper) DepositAccount(c context.Context, req *types.QueryDepositAccount
 }
 
 // DelegatorIntent returns information about the delegation intent of the caller for the given zone.
-func (k Keeper) DelegatorIntent(c context.Context, req *types.QueryDelegatorIntentRequest) (*types.QueryDelegatorIntentResponse, error) {
+func (k *Keeper) DelegatorIntent(c context.Context, req *types.QueryDelegatorIntentRequest) (*types.QueryDelegatorIntentResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -108,7 +108,7 @@ func (k Keeper) DelegatorIntent(c context.Context, req *types.QueryDelegatorInte
 	return &types.QueryDelegatorIntentResponse{Intent: &intent}, nil
 }
 
-func (k Keeper) Delegations(c context.Context, req *types.QueryDelegationsRequest) (*types.QueryDelegationsResponse, error) {
+func (k *Keeper) Delegations(c context.Context, req *types.QueryDelegationsRequest) (*types.QueryDelegationsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -132,7 +132,7 @@ func (k Keeper) Delegations(c context.Context, req *types.QueryDelegationsReques
 	return &types.QueryDelegationsResponse{Delegations: delegations, Tvl: sum}, nil
 }
 
-func (k Keeper) Receipts(c context.Context, req *types.QueryReceiptsRequest) (*types.QueryReceiptsResponse, error) {
+func (k *Keeper) Receipts(c context.Context, req *types.QueryReceiptsRequest) (*types.QueryReceiptsResponse, error) {
 	// TODO: implement pagination
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -155,7 +155,7 @@ func (k Keeper) Receipts(c context.Context, req *types.QueryReceiptsRequest) (*t
 	return &types.QueryReceiptsResponse{Receipts: receipts}, nil
 }
 
-func (k Keeper) ZoneWithdrawalRecords(c context.Context, req *types.QueryWithdrawalRecordsRequest) (*types.QueryWithdrawalRecordsResponse, error) {
+func (k *Keeper) ZoneWithdrawalRecords(c context.Context, req *types.QueryWithdrawalRecordsRequest) (*types.QueryWithdrawalRecordsResponse, error) {
 	// TODO: implement pagination
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -179,7 +179,7 @@ func (k Keeper) ZoneWithdrawalRecords(c context.Context, req *types.QueryWithdra
 	return &types.QueryWithdrawalRecordsResponse{Withdrawals: withdrawalrecords}, nil
 }
 
-func (k Keeper) WithdrawalRecords(c context.Context, req *types.QueryWithdrawalRecordsRequest) (*types.QueryWithdrawalRecordsResponse, error) {
+func (k *Keeper) WithdrawalRecords(c context.Context, req *types.QueryWithdrawalRecordsRequest) (*types.QueryWithdrawalRecordsResponse, error) {
 	// TODO: implement pagination
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -192,7 +192,7 @@ func (k Keeper) WithdrawalRecords(c context.Context, req *types.QueryWithdrawalR
 	return &types.QueryWithdrawalRecordsResponse{Withdrawals: withdrawalrecords}, nil
 }
 
-func (k Keeper) UnbondingRecords(c context.Context, req *types.QueryUnbondingRecordsRequest) (*types.QueryUnbondingRecordsResponse, error) {
+func (k *Keeper) UnbondingRecords(c context.Context, req *types.QueryUnbondingRecordsRequest) (*types.QueryUnbondingRecordsResponse, error) {
 	// TODO: implement pagination
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -205,7 +205,7 @@ func (k Keeper) UnbondingRecords(c context.Context, req *types.QueryUnbondingRec
 	return &types.QueryUnbondingRecordsResponse{Unbondings: unbondings}, nil
 }
 
-func (k Keeper) RedelegationRecords(c context.Context, req *types.QueryRedelegationRecordsRequest) (*types.QueryRedelegationRecordsResponse, error) {
+func (k *Keeper) RedelegationRecords(c context.Context, req *types.QueryRedelegationRecordsRequest) (*types.QueryRedelegationRecordsResponse, error) {
 	// TODO: implement pagination
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")

--- a/x/interchainstaking/keeper/grpc_query_test.go
+++ b/x/interchainstaking/keeper/grpc_query_test.go
@@ -211,7 +211,7 @@ func (suite *KeeperTestSuite) TestKeeper_DelegatorIntent() {
 					},
 				}
 				for _, intent := range intents {
-					icsKeeper.SetIntent(ctx, zone, intent, false)
+					icsKeeper.SetIntent(ctx, &zone, intent, false)
 				}
 			},
 			&types.QueryDelegatorIntentRequest{
@@ -383,7 +383,7 @@ func (suite *KeeperTestSuite) TestKeeper_Receipts() {
 				// set receipts
 				receipt := icsKeeper.NewReceipt(
 					ctx,
-					zone,
+					&zone,
 					testAddress,
 					"testReceiptHash#01",
 					sdk.NewCoins(

--- a/x/interchainstaking/keeper/hooks.go
+++ b/x/interchainstaking/keeper/hooks.go
@@ -18,9 +18,9 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 	if epochIdentifier == "epoch" {
 		k.Logger(ctx).Info("handling epoch end")
 
-		k.IterateZones(ctx, func(index int64, zoneInfo types.Zone) (stop bool) {
+		k.IterateZones(ctx, func(index int64, zoneInfo *types.Zone) (stop bool) {
 			k.Logger(ctx).Info("taking a snapshot of intents")
-			err := k.AggregateIntents(ctx, &zoneInfo)
+			err := k.AggregateIntents(ctx, zoneInfo)
 			if err != nil {
 				// we can and need not panic here; logging the error is sufficient.
 				// an error here is not expected, but also not terminal.
@@ -35,7 +35,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 				return false
 			}
 
-			if err := k.HandleQueuedUnbondings(ctx, &zoneInfo, epochNumber); err != nil {
+			if err := k.HandleQueuedUnbondings(ctx, zoneInfo, epochNumber); err != nil {
 				k.Logger(ctx).Error(err.Error())
 				// we can and need not panic here; logging the error is sufficient.
 				// an error here is not expected, but also not terminal.
@@ -95,7 +95,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			// WithdrawalWaitgroup is decremented in RewardsCallback
 			zoneInfo.WithdrawalWaitgroup++
 			k.Logger(ctx).Info("Incrementing waitgroup for delegation", "value", zoneInfo.WithdrawalWaitgroup)
-			k.SetZone(ctx, &zoneInfo)
+			k.SetZone(ctx, zoneInfo)
 
 			return false
 		})

--- a/x/interchainstaking/keeper/hooks.go
+++ b/x/interchainstaking/keeper/hooks.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+func (k *Keeper) BeforeEpochStart(_ sdk.Context, _ string, _ int64) error {
 	return nil
 }
 
-func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+func (k *Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
 	// every epoch
 	if epochIdentifier == "epoch" {
 		k.Logger(ctx).Info("handling epoch end")
@@ -105,14 +105,14 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 
 // ___________________________________________________________________________________________________
 
-// Hooks wrapper struct for incentives keeper
+// Hooks wrapper struct for interchainstaking keeper
 type Hooks struct {
-	k Keeper
+	k *Keeper
 }
 
 var _ epochstypes.EpochHooks = Hooks{}
 
-func (k Keeper) Hooks() Hooks {
+func (k *Keeper) Hooks() Hooks {
 	return Hooks{k}
 }
 

--- a/x/interchainstaking/keeper/ibc_channel_handlers.go
+++ b/x/interchainstaking/keeper/ibc_channel_handlers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func (k Keeper) HandleChannelOpenAck(ctx sdk.Context, portID string, connectionID string) error {
+func (k *Keeper) HandleChannelOpenAck(ctx sdk.Context, portID string, connectionID string) error {
 	chainID, err := k.GetChainID(ctx, connectionID)
 	if err != nil {
 		ctx.Logger().Error(

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -1032,7 +1032,7 @@ func (k *Keeper) HandleWithdrawRewards(ctx sdk.Context, msg sdk.Msg) error {
 	}
 }
 
-func DistributeRewardsFromWithdrawAccount(k Keeper, ctx sdk.Context, args []byte, query queryTypes.Query) error {
+func DistributeRewardsFromWithdrawAccount(k *Keeper, ctx sdk.Context, args []byte, query queryTypes.Query) error {
 	zone, found := k.GetZone(ctx, query.ChainId)
 	if !found {
 		return fmt.Errorf("unable to find zone for %s", query.ChainId)

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -818,7 +818,7 @@ func (k *Keeper) HandleDelegate(ctx sdk.Context, msg sdk.Msg, memo string) error
 	}
 
 	if memo != "rewards" {
-		receipt, found := k.GetReceipt(ctx, GetReceiptKey(zone.ChainId, memo))
+		receipt, found := k.GetReceipt(ctx, types.GetReceiptKey(zone.ChainId, memo))
 		if !found {
 			return fmt.Errorf("unable to find receipt for hash %s", memo)
 		}

--- a/x/interchainstaking/keeper/ibc_packet_handlers_test.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers_test.go
@@ -1311,7 +1311,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToIntentChange() {
 	app.InterchainstakingKeeper.SetZone(ctx, &zone)
 
 	// trigger rebalance
-	err := app.InterchainstakingKeeper.Rebalance(ctx, zone, 1)
+	err := app.InterchainstakingKeeper.Rebalance(ctx, &zone, 1)
 	s.Require().NoError(err)
 
 	//change intents to trigger redelegations from val[3]
@@ -1324,7 +1324,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToIntentChange() {
 	zone.AggregateIntent = intents
 
 	// trigger rebalance
-	err = app.InterchainstakingKeeper.Rebalance(ctx, zone, 2)
+	err = app.InterchainstakingKeeper.Rebalance(ctx, &zone, 2)
 
 	// mock ack for redelegations
 	app.InterchainstakingKeeper.IteratePrefixedRedelegationRecords(ctx, []byte(zone.ChainId), func(idx int64, _ []byte, record icstypes.RedelegationRecord) (stop bool) {
@@ -1360,7 +1360,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToIntentChange() {
 	zone.AggregateIntent = intents
 
 	// trigger rebalance
-	err = app.InterchainstakingKeeper.Rebalance(ctx, zone, 3)
+	err = app.InterchainstakingKeeper.Rebalance(ctx, &zone, 3)
 
 	//check for redelegations originating from val[0], they should not be present
 	_, present = app.InterchainstakingKeeper.GetRedelegationRecord(ctx, zone.ChainId, vals[0].ValoperAddress, vals[1].ValoperAddress, 3)
@@ -1420,7 +1420,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToDelegationChange() {
 	app.InterchainstakingKeeper.SetZone(ctx, &zone)
 
 	// trigger rebalance
-	err := app.InterchainstakingKeeper.Rebalance(ctx, zone, 1)
+	err := app.InterchainstakingKeeper.Rebalance(ctx, &zone, 1)
 	s.Require().NoError(err)
 
 	app.InterchainstakingKeeper.IterateAllDelegations(ctx, &zone, func(delegation icstypes.Delegation) bool {
@@ -1432,7 +1432,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToDelegationChange() {
 	})
 
 	// trigger rebalance
-	err = app.InterchainstakingKeeper.Rebalance(ctx, zone, 2)
+	err = app.InterchainstakingKeeper.Rebalance(ctx, &zone, 2)
 	s.Require().NoError(err)
 
 	// mock ack for redelegations
@@ -1473,7 +1473,7 @@ func (s *KeeperTestSuite) TestRebalanceDueToDelegationChange() {
 	})
 
 	// trigger rebalance
-	err = app.InterchainstakingKeeper.Rebalance(ctx, zone, 3)
+	err = app.InterchainstakingKeeper.Rebalance(ctx, &zone, 3)
 
 	//check for redelegations originating from val[1], they should not be present
 	_, present = app.InterchainstakingKeeper.GetRedelegationRecord(ctx, zone.ChainId, vals[2].ValoperAddress, vals[0].ValoperAddress, 3)

--- a/x/interchainstaking/keeper/intent.go
+++ b/x/interchainstaking/keeper/intent.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func (k Keeper) getStoreKey(zone *types.Zone, snapshot bool) []byte {
+func (k *Keeper) getStoreKey(zone *types.Zone, snapshot bool) []byte {
 	if snapshot {
 		return append(types.KeyPrefixSnapshotIntent, []byte(zone.ChainId)...)
 	}
@@ -21,7 +21,7 @@ func (k Keeper) getStoreKey(zone *types.Zone, snapshot bool) []byte {
 }
 
 // GetIntent returns intent info by zone and delegator
-func (k Keeper) GetIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) (types.DelegatorIntent, bool) {
+func (k *Keeper) GetIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) (types.DelegatorIntent, bool) {
 	intent := types.DelegatorIntent{}
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	bz := store.Get([]byte(delegator))
@@ -34,20 +34,20 @@ func (k Keeper) GetIntent(ctx sdk.Context, zone *types.Zone, delegator string, s
 }
 
 // SetIntent store the delegator intent
-func (k Keeper) SetIntent(ctx sdk.Context, zone *types.Zone, intent types.DelegatorIntent, snapshot bool) {
+func (k *Keeper) SetIntent(ctx sdk.Context, zone *types.Zone, intent types.DelegatorIntent, snapshot bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	bz := k.cdc.MustMarshal(&intent)
 	store.Set([]byte(intent.Delegator), bz)
 }
 
 // DeleteIntent deletes delegator intent
-func (k Keeper) DeleteIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) {
+func (k *Keeper) DeleteIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	store.Delete([]byte(delegator))
 }
 
 // IterateIntents iterate through intents for a given zone
-func (k Keeper) IterateIntents(ctx sdk.Context, zone *types.Zone, snapshot bool, fn func(index int64, intent types.DelegatorIntent) (stop bool)) {
+func (k *Keeper) IterateIntents(ctx sdk.Context, zone *types.Zone, snapshot bool, fn func(index int64, intent types.DelegatorIntent) (stop bool)) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 
 	iterator := sdk.KVStorePrefixIterator(store, nil)
@@ -69,7 +69,7 @@ func (k Keeper) IterateIntents(ctx sdk.Context, zone *types.Zone, snapshot bool,
 }
 
 // AllIntents returns every intent in the store for the specified zone
-func (k Keeper) AllIntents(ctx sdk.Context, zone *types.Zone, snapshot bool) []types.DelegatorIntent {
+func (k *Keeper) AllIntents(ctx sdk.Context, zone *types.Zone, snapshot bool) []types.DelegatorIntent {
 	intents := []types.DelegatorIntent{}
 	k.IterateIntents(ctx, zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
 		intents = append(intents, intent)
@@ -79,7 +79,7 @@ func (k Keeper) AllIntents(ctx sdk.Context, zone *types.Zone, snapshot bool) []t
 }
 
 // AllIntentsAsPointer returns every intent in the store for the specified zone
-func (k Keeper) AllIntentsAsPointer(ctx sdk.Context, zone *types.Zone, snapshot bool) []*types.DelegatorIntent {
+func (k *Keeper) AllIntentsAsPointer(ctx sdk.Context, zone *types.Zone, snapshot bool) []*types.DelegatorIntent {
 	intents := []*types.DelegatorIntent{}
 	k.IterateIntents(ctx, zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
 		intents = append(intents, &intent)

--- a/x/interchainstaking/keeper/intent.go
+++ b/x/interchainstaking/keeper/intent.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func (k Keeper) getStoreKey(zone types.Zone, snapshot bool) []byte {
+func (k Keeper) getStoreKey(zone *types.Zone, snapshot bool) []byte {
 	if snapshot {
 		return append(types.KeyPrefixSnapshotIntent, []byte(zone.ChainId)...)
 	}
@@ -21,7 +21,7 @@ func (k Keeper) getStoreKey(zone types.Zone, snapshot bool) []byte {
 }
 
 // GetIntent returns intent info by zone and delegator
-func (k Keeper) GetIntent(ctx sdk.Context, zone types.Zone, delegator string, snapshot bool) (types.DelegatorIntent, bool) {
+func (k Keeper) GetIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) (types.DelegatorIntent, bool) {
 	intent := types.DelegatorIntent{}
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	bz := store.Get([]byte(delegator))
@@ -34,20 +34,20 @@ func (k Keeper) GetIntent(ctx sdk.Context, zone types.Zone, delegator string, sn
 }
 
 // SetIntent store the delegator intent
-func (k Keeper) SetIntent(ctx sdk.Context, zone types.Zone, intent types.DelegatorIntent, snapshot bool) {
+func (k Keeper) SetIntent(ctx sdk.Context, zone *types.Zone, intent types.DelegatorIntent, snapshot bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	bz := k.cdc.MustMarshal(&intent)
 	store.Set([]byte(intent.Delegator), bz)
 }
 
 // DeleteIntent deletes delegator intent
-func (k Keeper) DeleteIntent(ctx sdk.Context, zone types.Zone, delegator string, snapshot bool) {
+func (k Keeper) DeleteIntent(ctx sdk.Context, zone *types.Zone, delegator string, snapshot bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 	store.Delete([]byte(delegator))
 }
 
 // IterateIntents iterate through intents for a given zone
-func (k Keeper) IterateIntents(ctx sdk.Context, zone types.Zone, snapshot bool, fn func(index int64, intent types.DelegatorIntent) (stop bool)) {
+func (k Keeper) IterateIntents(ctx sdk.Context, zone *types.Zone, snapshot bool, fn func(index int64, intent types.DelegatorIntent) (stop bool)) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.getStoreKey(zone, snapshot))
 
 	iterator := sdk.KVStorePrefixIterator(store, nil)
@@ -69,7 +69,7 @@ func (k Keeper) IterateIntents(ctx sdk.Context, zone types.Zone, snapshot bool, 
 }
 
 // AllIntents returns every intent in the store for the specified zone
-func (k Keeper) AllIntents(ctx sdk.Context, zone types.Zone, snapshot bool) []types.DelegatorIntent {
+func (k Keeper) AllIntents(ctx sdk.Context, zone *types.Zone, snapshot bool) []types.DelegatorIntent {
 	intents := []types.DelegatorIntent{}
 	k.IterateIntents(ctx, zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
 		intents = append(intents, intent)
@@ -78,8 +78,8 @@ func (k Keeper) AllIntents(ctx sdk.Context, zone types.Zone, snapshot bool) []ty
 	return intents
 }
 
-// AllIntents returns every intent in the store for the specified zone
-func (k Keeper) AllIntentsAsPointer(ctx sdk.Context, zone types.Zone, snapshot bool) []*types.DelegatorIntent {
+// AllIntentsAsPointer returns every intent in the store for the specified zone
+func (k Keeper) AllIntentsAsPointer(ctx sdk.Context, zone *types.Zone, snapshot bool) []*types.DelegatorIntent {
 	intents := []*types.DelegatorIntent{}
 	k.IterateIntents(ctx, zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
 		intents = append(intents, &intent)
@@ -95,7 +95,7 @@ func (k *Keeper) AggregateIntents(ctx sdk.Context, zone *types.Zone) error {
 	ordinalizedIntentSum := sdk.ZeroDec()
 	// reduce intents
 
-	k.IterateIntents(ctx, *zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
+	k.IterateIntents(ctx, zone, snapshot, func(_ int64, intent types.DelegatorIntent) (stop bool) {
 		// addr, localErr := sdk.AccAddressFromBech32(intent.Delegator)
 		// if localErr != nil {
 		// 	err = localErr
@@ -153,7 +153,7 @@ func (k *Keeper) AggregateIntents(ctx sdk.Context, zone *types.Zone) error {
 	return nil
 }
 
-func (k *Keeper) UpdateIntent(ctx sdk.Context, sender sdk.AccAddress, zone types.Zone, inAmount sdk.Coins, memo string) error {
+func (k *Keeper) UpdateIntent(ctx sdk.Context, sender sdk.AccAddress, zone *types.Zone, inAmount sdk.Coins, memo string) error {
 	snapshot := false
 	// this is here because we need access to the bankKeeper to ordinalize intent
 	intent, _ := k.GetIntent(ctx, zone, sender.String(), snapshot)

--- a/x/interchainstaking/keeper/intent_test.go
+++ b/x/interchainstaking/keeper/intent_test.go
@@ -25,13 +25,13 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	zoneValidatorAddresses := zone.GetValidatorsAddressesAsSlice()
 
 	// check that there are no intents
-	intents := icsKeeper.AllIntents(ctx, zone, false)
+	intents := icsKeeper.AllIntents(ctx, &zone, false)
 	suite.Require().Len(intents, 0)
 
 	// set intents for testAddress
 	icsKeeper.SetIntent(
 		ctx,
-		zone,
+		&zone,
 		icstypes.DelegatorIntent{
 			Delegator: testAddress,
 			Intents: icstypes.ValidatorIntents{
@@ -58,7 +58,7 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	// set intents for user1
 	icsKeeper.SetIntent(
 		ctx,
-		zone,
+		&zone,
 		icstypes.DelegatorIntent{
 			Delegator: user1.String(),
 			Intents: icstypes.ValidatorIntents{
@@ -85,7 +85,7 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	// set intents for user2
 	icsKeeper.SetIntent(
 		ctx,
-		zone,
+		&zone,
 		icstypes.DelegatorIntent{
 			Delegator: user2.String(),
 			Intents: icstypes.ValidatorIntents{
@@ -107,14 +107,14 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	)
 
 	// check for intents set above
-	intents = icsKeeper.AllIntents(ctx, zone, false)
+	intents = icsKeeper.AllIntents(ctx, &zone, false)
 	suite.Require().Len(intents, 3)
 
 	// delete intent for testAddress
-	icsKeeper.DeleteIntent(ctx, zone, testAddress, false)
+	icsKeeper.DeleteIntent(ctx, &zone, testAddress, false)
 
 	// check intents
-	intents = icsKeeper.AllIntents(ctx, zone, false)
+	intents = icsKeeper.AllIntents(ctx, &zone, false)
 	suite.Require().Len(intents, 2)
 
 	suite.T().Logf("intents:\n%+v\n", intents)
@@ -123,7 +123,7 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	err := icsKeeper.UpdateIntent(
 		ctx,
 		user2,
-		zone,
+		&zone,
 		sdk.NewCoins(
 			sdk.NewCoin(
 				zone.BaseDenom,
@@ -135,7 +135,7 @@ func (suite *KeeperTestSuite) TestKeeper_IntentStore() {
 	suite.Require().NoError(err)
 
 	// load and match pointers
-	intentsPointers := icsKeeper.AllIntentsAsPointer(ctx, zone, false)
+	intentsPointers := icsKeeper.AllIntentsAsPointer(ctx, &zone, false)
 	for i, ip := range intentsPointers {
 		suite.Require().Equal(intents[i], *ip)
 	}
@@ -321,7 +321,7 @@ func (suite *KeeperTestSuite) TestAggregateIntent() {
 			}
 
 			for _, intent := range tt.intents(zone) {
-				icsKeeper.SetIntent(ctx, zone, intent, false)
+				icsKeeper.SetIntent(ctx, &zone, intent, false)
 			}
 
 			icsKeeper.AggregateIntents(ctx, &zone)

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -85,11 +85,11 @@ func (k *Keeper) GetGovAuthority(ctx sdk.Context) string {
 }
 
 // Logger returns a module-specific logger.
-func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+func (k *Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-func (k Keeper) GetCodec() codec.Codec {
+func (k *Keeper) GetCodec() codec.Codec {
 	return k.cdc
 }
 
@@ -122,7 +122,7 @@ func (k *Keeper) GetConnectionForPort(ctx sdk.Context, port string) (string, err
 }
 
 // IteratePortConnections iterates through all of the delegations.
-func (k Keeper) IteratePortConnections(ctx sdk.Context, cb func(pc types.PortConnectionTuple) (stop bool)) {
+func (k *Keeper) IteratePortConnections(ctx sdk.Context, cb func(pc types.PortConnectionTuple) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
 
 	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefixPortMapping)
@@ -138,7 +138,7 @@ func (k Keeper) IteratePortConnections(ctx sdk.Context, cb func(pc types.PortCon
 }
 
 // AllPortConnections returns all delegations used during genesis dump.
-func (k Keeper) AllPortConnections(ctx sdk.Context) (pcs []types.PortConnectionTuple) {
+func (k *Keeper) AllPortConnections(ctx sdk.Context) (pcs []types.PortConnectionTuple) {
 	k.IteratePortConnections(ctx, func(pc types.PortConnectionTuple) bool {
 		pcs = append(pcs, pc)
 		return false
@@ -151,7 +151,7 @@ func (k Keeper) AllPortConnections(ctx sdk.Context) (pcs []types.PortConnectionT
 // * some of these functions (or portions thereof) may be changed to single
 //   query type functions, dependent upon callback features / capabilities;
 
-func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo *types.Zone, data []byte, request []byte) error {
+func (k *Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo *types.Zone, data []byte, request []byte) error {
 	validatorsRes, err := k.UnmarshalValidatorResponse(data)
 	if err != nil {
 		k.Logger(ctx).Error("unable to unmarshal validators info for zone", "zone", zoneInfo.ChainId, "err", err)
@@ -204,7 +204,7 @@ func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo *types.Zone, data
 	return nil
 }
 
-func (k Keeper) SetValidatorForZone(ctx sdk.Context, zone *types.Zone, data []byte) error {
+func (k *Keeper) SetValidatorForZone(ctx sdk.Context, zone *types.Zone, data []byte) error {
 	validator, err := k.UnmarshalValidator(data)
 	if err != nil {
 		k.Logger(ctx).Error("unable to unmarshal validator info for zone", "zone", zone.ChainId, "err", err)
@@ -294,7 +294,7 @@ func (k Keeper) SetValidatorForZone(ctx sdk.Context, zone *types.Zone, data []by
 	return nil
 }
 
-func (k Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone *types.Zone, valoper string, delta sdk.Dec) error {
+func (k *Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone *types.Zone, valoper string, delta sdk.Dec) error {
 	var err error
 	k.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, WithdrawStatusUnbond, func(_ int64, record types.WithdrawalRecord) bool {
 		recordSubAmount := sdkmath.ZeroInt()
@@ -316,7 +316,7 @@ func (k Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone *types.Zon
 	return err
 }
 
-func (k Keeper) depositInterval(ctx sdk.Context) zoneItrFn {
+func (k *Keeper) depositInterval(ctx sdk.Context) zoneItrFn {
 	return func(index int64, zoneInfo *types.Zone) (stop bool) {
 		if zoneInfo.DepositAddress != nil {
 			if !zoneInfo.DepositAddress.Balance.Empty() {
@@ -350,7 +350,7 @@ func (k *Keeper) GetCommissionRate(ctx sdk.Context) sdk.Dec {
 }
 
 // MigrateParams fetches params, adds ClaimsEnabled field and re-sets params.
-func (k Keeper) MigrateParams(ctx sdk.Context) {
+func (k *Keeper) MigrateParams(ctx sdk.Context) {
 	params := types.Params{}
 	params.DepositInterval = k.GetParam(ctx, types.KeyDepositInterval)
 	params.CommissionRate = k.GetCommissionRate(ctx)
@@ -360,17 +360,17 @@ func (k Keeper) MigrateParams(ctx sdk.Context) {
 	k.paramStore.SetParamSet(ctx, &params)
 }
 
-func (k Keeper) GetParams(clientCtx sdk.Context) (params types.Params) {
+func (k *Keeper) GetParams(clientCtx sdk.Context) (params types.Params) {
 	k.paramStore.GetParamSet(clientCtx, &params)
 	return params
 }
 
 // SetParams sets the distribution parameters to the param space.
-func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+func (k *Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramStore.SetParamSet(ctx, &params)
 }
 
-func (k Keeper) GetChainID(ctx sdk.Context, connectionID string) (string, error) {
+func (k *Keeper) GetChainID(ctx sdk.Context, connectionID string) (string, error) {
 	conn, found := k.IBCKeeper.ConnectionKeeper.GetConnection(ctx, connectionID)
 	if !found {
 		return "", fmt.Errorf("invalid connection id, \"%s\" not found", connectionID)
@@ -387,7 +387,7 @@ func (k Keeper) GetChainID(ctx sdk.Context, connectionID string) (string, error)
 	return client.ChainId, nil
 }
 
-func (k Keeper) GetChainIDFromContext(ctx sdk.Context) (string, error) {
+func (k *Keeper) GetChainIDFromContext(ctx sdk.Context) (string, error) {
 	connectionID := ctx.Context().Value(utils.ContextKey("connectionID"))
 	if connectionID == nil {
 		return "", errors.New("connectionID not in context")
@@ -396,7 +396,7 @@ func (k Keeper) GetChainIDFromContext(ctx sdk.Context) (string, error) {
 	return k.GetChainID(ctx, connectionID.(string))
 }
 
-func (k Keeper) EmitPerformanceBalanceQuery(ctx sdk.Context, zone *types.Zone) error {
+func (k *Keeper) EmitPerformanceBalanceQuery(ctx sdk.Context, zone *types.Zone) error {
 	_, addr, err := bech32.DecodeAndConvert(zone.PerformanceAddress.Address)
 	if err != nil {
 		return err
@@ -419,7 +419,7 @@ func (k Keeper) EmitPerformanceBalanceQuery(ctx sdk.Context, zone *types.Zone) e
 	return nil
 }
 
-func (k Keeper) EmitValSetQuery(ctx sdk.Context, zone *types.Zone, validatorsReq stakingtypes.QueryValidatorsRequest, period sdkmath.Int) error {
+func (k *Keeper) EmitValSetQuery(ctx sdk.Context, zone *types.Zone, validatorsReq stakingtypes.QueryValidatorsRequest, period sdkmath.Int) error {
 	bz, err := k.cdc.Marshal(&validatorsReq)
 	if err != nil {
 		return errors.New("failed to marshal valset pagination request")
@@ -440,7 +440,7 @@ func (k Keeper) EmitValSetQuery(ctx sdk.Context, zone *types.Zone, validatorsReq
 	return nil
 }
 
-func (k Keeper) EmitValidatorQuery(ctx sdk.Context, zone *types.Zone, validator stakingtypes.Validator) {
+func (k *Keeper) EmitValidatorQuery(ctx sdk.Context, zone *types.Zone, validator stakingtypes.Validator) {
 	_, addr, _ := bech32.DecodeAndConvert(validator.OperatorAddress)
 	data := stakingtypes.GetValidatorKey(addr)
 	k.ICQKeeper.MakeRequest(
@@ -456,7 +456,7 @@ func (k Keeper) EmitValidatorQuery(ctx sdk.Context, zone *types.Zone, validator 
 	)
 }
 
-func (k Keeper) EmitDepositIntervalQuery(ctx sdk.Context, zone *types.Zone) {
+func (k *Keeper) EmitDepositIntervalQuery(ctx sdk.Context, zone *types.Zone) {
 	req := tx.GetTxsEventRequest{
 		Events: []string{
 			"transfer.recipient='" + zone.DepositAddress.GetAddress() + "'",
@@ -565,7 +565,7 @@ func (k *Keeper) Rebalance(ctx sdk.Context, zone *types.Zone, epochNumber int64)
 }
 
 // UnmarshalValidatorResponse attempts to umarshal  a byte slice into a QueryValidatorsResponse.
-func (k Keeper) UnmarshalValidatorResponse(data []byte) (stakingtypes.QueryValidatorsResponse, error) {
+func (k *Keeper) UnmarshalValidatorResponse(data []byte) (stakingtypes.QueryValidatorsResponse, error) {
 	validatorsRes := stakingtypes.QueryValidatorsResponse{}
 	if len(data) == 0 {
 		return validatorsRes, errors.New("attempted to unmarshal zero length byte slice (8)")
@@ -579,7 +579,7 @@ func (k Keeper) UnmarshalValidatorResponse(data []byte) (stakingtypes.QueryValid
 }
 
 // UnmarshalValidatorRequest attempts to umarshal  a byte slice into a QueryValidatorsRequest.
-func (k Keeper) UnmarshalValidatorRequest(data []byte) (stakingtypes.QueryValidatorsRequest, error) {
+func (k *Keeper) UnmarshalValidatorRequest(data []byte) (stakingtypes.QueryValidatorsRequest, error) {
 	validatorsReq := stakingtypes.QueryValidatorsRequest{}
 	if len(data) == 0 {
 		return validatorsReq, errors.New("attempted to unmarshal zero length byte slice (8)")
@@ -593,7 +593,7 @@ func (k Keeper) UnmarshalValidatorRequest(data []byte) (stakingtypes.QueryValida
 }
 
 // UnmarshalValidator attempts to umarshal  a byte slice into a Validator.
-func (k Keeper) UnmarshalValidator(data []byte) (stakingtypes.Validator, error) {
+func (k *Keeper) UnmarshalValidator(data []byte) (stakingtypes.Validator, error) {
 	validator := stakingtypes.Validator{}
 	if len(data) == 0 {
 		return validator, errors.New("attempted to unmarshal zero length byte slice (9)")

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -22,7 +21,7 @@ import (
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/controller/keeper"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v5/modules/apps/transfer/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v5/modules/core/keeper"
@@ -148,37 +147,11 @@ func (k Keeper) AllPortConnections(ctx sdk.Context) (pcs []types.PortConnectionT
 	return pcs
 }
 
-func (k Keeper) UnmarshalValidatorResponse(data []byte) (stakingTypes.QueryValidatorsResponse, error) {
-	validatorsRes := stakingTypes.QueryValidatorsResponse{}
-	if len(data) == 0 {
-		return validatorsRes, errors.New("attempted to unmarshal zero length byte slice (8)")
-	}
-	err := k.cdc.Unmarshal(data, &validatorsRes)
-	if err != nil {
-		return validatorsRes, err
-	}
-
-	return validatorsRes, nil
-}
-
-func (k Keeper) UnmarshalValidatorRequest(data []byte) (stakingTypes.QueryValidatorsRequest, error) {
-	validatorsReq := stakingTypes.QueryValidatorsRequest{}
-	if len(data) == 0 {
-		return validatorsReq, errors.New("attempted to unmarshal zero length byte slice (8)")
-	}
-	err := k.cdc.Unmarshal(data, &validatorsReq)
-	if err != nil {
-		return validatorsReq, err
-	}
-
-	return validatorsReq, nil
-}
-
 // ### Interval functions >>>
 // * some of these functions (or portions thereof) may be changed to single
 //   query type functions, dependent upon callback features / capabilities;
 
-func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo types.Zone, data []byte, request []byte) error {
+func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo *types.Zone, data []byte, request []byte) error {
 	validatorsRes, err := k.UnmarshalValidatorResponse(data)
 	if err != nil {
 		k.Logger(ctx).Error("unable to unmarshal validators info for zone", "zone", zoneInfo.ChainId, "err", err)
@@ -196,23 +169,11 @@ func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo types.Zone, data 
 			validatorsReq.Pagination = new(query.PageRequest)
 		}
 		validatorsReq.Pagination.Key = validatorsRes.Pagination.NextKey
-		bz, err := k.cdc.Marshal(&validatorsReq)
-		if err != nil {
-			return errors.New("failed to marshal valset pagination request")
-		}
 		k.Logger(ctx).Debug("Found pagination nextKey in valset; resubmitting...")
-
-		k.ICQKeeper.MakeRequest(
-			ctx,
-			zoneInfo.ConnectionId,
-			zoneInfo.ChainId,
-			"cosmos.staking.v1beta1.Query/Validators",
-			bz,
-			sdk.NewInt(-1),
-			types.ModuleName,
-			"valset",
-			0,
-		)
+		err = k.EmitValSetQuery(ctx, zoneInfo, validatorsReq, sdkmath.NewInt(-1))
+		if err != nil {
+			return nil
+		}
 	}
 
 	for _, validator := range validatorsRes.Validators {
@@ -234,33 +195,17 @@ func (k Keeper) SetValidatorsForZone(ctx sdk.Context, zoneInfo types.Zone, data 
 		}
 
 		if toQuery {
-			_, addr, _ := bech32.DecodeAndConvert(validator.OperatorAddress)
-			data := stakingTypes.GetValidatorKey(addr)
-			k.ICQKeeper.MakeRequest(
-				ctx,
-				zoneInfo.ConnectionId,
-				zoneInfo.ChainId,
-				"store/staking/key",
-				data,
-				sdk.NewInt(-1),
-				types.ModuleName,
-				"validator",
-				0,
-			)
+			k.EmitValidatorQuery(ctx, zoneInfo, validator)
 		}
 	}
 
 	// also do this for Unbonded and Unbonding
-	k.SetZone(ctx, &zoneInfo)
+	k.SetZone(ctx, zoneInfo)
 	return nil
 }
 
-func SetValidatorForZone(k *Keeper, ctx sdk.Context, zone types.Zone, data []byte) error {
-	validator := stakingTypes.Validator{}
-	if len(data) == 0 {
-		return errors.New("attempted to unmarshal zero length byte slice (9)")
-	}
-	err := k.cdc.Unmarshal(data, &validator)
+func (k Keeper) SetValidatorForZone(ctx sdk.Context, zone *types.Zone, data []byte) error {
+	validator, err := k.UnmarshalValidator(data)
 	if err != nil {
 		k.Logger(ctx).Error("unable to unmarshal validator info for zone", "zone", zone.ChainId, "err", err)
 		return err
@@ -286,12 +231,11 @@ func SetValidatorForZone(k *Keeper, ctx sdk.Context, zone types.Zone, data []byt
 		})
 		zone.Validators = zone.GetValidatorsSorted()
 
-		if err := k.MakePerformanceDelegation(ctx, &zone, validator.OperatorAddress); err != nil {
+		if err := k.MakePerformanceDelegation(ctx, zone, validator.OperatorAddress); err != nil {
 			return err
 		}
 
 	} else {
-
 		if !val.Jailed && validator.IsJailed() {
 			k.Logger(ctx).Info("Transitioning validator to jailed state", "valoper", validator.OperatorAddress)
 
@@ -339,26 +283,26 @@ func SetValidatorForZone(k *Keeper, ctx sdk.Context, zone types.Zone, data []byt
 			val.Status = validator.Status.String()
 		}
 
-		if _, found := k.GetPerformanceDelegation(ctx, &zone, validator.OperatorAddress); !found {
-			if err := k.MakePerformanceDelegation(ctx, &zone, validator.OperatorAddress); err != nil {
+		if _, found := k.GetPerformanceDelegation(ctx, zone, validator.OperatorAddress); !found {
+			if err := k.MakePerformanceDelegation(ctx, zone, validator.OperatorAddress); err != nil {
 				return err
 			}
 		}
 	}
 
-	k.SetZone(ctx, &zone)
+	k.SetZone(ctx, zone)
 	return nil
 }
 
-func (k Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone types.Zone, valoper string, delta sdk.Dec) error {
+func (k Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone *types.Zone, valoper string, delta sdk.Dec) error {
 	var err error
 	k.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, WithdrawStatusUnbond, func(_ int64, record types.WithdrawalRecord) bool {
-		recordSubAmount := math.ZeroInt()
+		recordSubAmount := sdkmath.ZeroInt()
 		distr := record.Distribution
 		for _, d := range distr {
 			if d.Valoper == valoper {
 				newAmount := sdk.NewDec(int64(d.Amount)).Quo(delta).TruncateInt()
-				thisSubAmount := math.NewInt(int64(d.Amount)).Sub(newAmount)
+				thisSubAmount := sdkmath.NewInt(int64(d.Amount)).Sub(newAmount)
 				recordSubAmount = recordSubAmount.Add(thisSubAmount)
 				d.Amount = newAmount.Uint64()
 				k.Logger(ctx).Info("Updated withdrawal record due to slashing", "valoper", valoper, "old_amount", d.Amount, "new_amount", newAmount.Int64(), "sub_amount", thisSubAmount.Int64())
@@ -373,13 +317,11 @@ func (k Keeper) UpdateWithdrawalRecordsForSlash(ctx sdk.Context, zone types.Zone
 }
 
 func (k Keeper) depositInterval(ctx sdk.Context) zoneItrFn {
-	return func(index int64, zoneInfo types.Zone) (stop bool) {
+	return func(index int64, zoneInfo *types.Zone) (stop bool) {
 		if zoneInfo.DepositAddress != nil {
 			if !zoneInfo.DepositAddress.Balance.Empty() {
 				k.Logger(ctx).Debug("balance is non zero", "balance", zoneInfo.DepositAddress.Balance)
-
-				req := tx.GetTxsEventRequest{Events: []string{"transfer.recipient='" + zoneInfo.DepositAddress.GetAddress() + "'"}, OrderBy: tx.OrderBy_ORDER_BY_DESC, Pagination: &query.PageRequest{Limit: types.TxRetrieveCount}}
-				k.ICQKeeper.MakeRequest(ctx, zoneInfo.ConnectionId, zoneInfo.ChainId, "cosmos.tx.v1beta1.Service/GetTxsEvent", k.cdc.MustMarshal(&req), sdk.NewInt(-1), types.ModuleName, "depositinterval", 0)
+				k.EmitDepositIntervalQuery(ctx, zoneInfo)
 
 			}
 		} else {
@@ -477,11 +419,72 @@ func (k Keeper) EmitPerformanceBalanceQuery(ctx sdk.Context, zone *types.Zone) e
 	return nil
 }
 
+func (k Keeper) EmitValSetQuery(ctx sdk.Context, zone *types.Zone, validatorsReq stakingtypes.QueryValidatorsRequest, period sdkmath.Int) error {
+	bz, err := k.cdc.Marshal(&validatorsReq)
+	if err != nil {
+		return errors.New("failed to marshal valset pagination request")
+	}
+
+	k.ICQKeeper.MakeRequest(
+		ctx,
+		zone.ConnectionId,
+		zone.ChainId,
+		"cosmos.staking.v1beta1.Query/Validators",
+		bz,
+		period,
+		types.ModuleName,
+		"valset",
+		0,
+	)
+
+	return nil
+}
+
+func (k Keeper) EmitValidatorQuery(ctx sdk.Context, zone *types.Zone, validator stakingtypes.Validator) {
+	_, addr, _ := bech32.DecodeAndConvert(validator.OperatorAddress)
+	data := stakingtypes.GetValidatorKey(addr)
+	k.ICQKeeper.MakeRequest(
+		ctx,
+		zone.ConnectionId,
+		zone.ChainId,
+		"store/staking/key",
+		data,
+		sdk.NewInt(-1),
+		types.ModuleName,
+		"validator",
+		0,
+	)
+}
+
+func (k Keeper) EmitDepositIntervalQuery(ctx sdk.Context, zone *types.Zone) {
+	req := tx.GetTxsEventRequest{
+		Events: []string{
+			"transfer.recipient='" + zone.DepositAddress.GetAddress() + "'",
+		},
+		OrderBy: tx.OrderBy_ORDER_BY_DESC,
+		Pagination: &query.PageRequest{
+			Limit: types.TxRetrieveCount,
+		},
+	}
+
+	k.ICQKeeper.MakeRequest(
+		ctx,
+		zone.ConnectionId,
+		zone.ChainId,
+		"cosmos.tx.v1beta1.Service/GetTxsEvent",
+		k.cdc.MustMarshal(&req),
+		sdk.NewInt(-1),
+		types.ModuleName,
+		"depositinterval",
+		0,
+	)
+}
+
 // redemption rate
 
-func (k *Keeper) UpdateRedemptionRate(ctx sdk.Context, zone types.Zone, epochRewards math.Int) {
-	delegationsInProcess := sdk.ZeroInt()
-	k.IterateZoneReceipts(ctx, &zone, func(_ int64, receipt types.Receipt) (stop bool) {
+func (k *Keeper) UpdateRedemptionRate(ctx sdk.Context, zone *types.Zone, epochRewards sdkmath.Int) {
+	delegationsInProcess := sdkmath.ZeroInt()
+	k.IterateZoneReceipts(ctx, zone, func(_ int64, receipt types.Receipt) (stop bool) {
 		if receipt.Completed == nil {
 			for _, coin := range receipt.Amount {
 				delegationsInProcess = delegationsInProcess.Add(coin.Amount) // we cannot simply choose
@@ -493,7 +496,7 @@ func (k *Keeper) UpdateRedemptionRate(ctx sdk.Context, zone types.Zone, epochRew
 	k.Logger(ctx).Info("Epochly rewards", "coins", epochRewards)
 	k.Logger(ctx).Info("Last redemption rate", "rate", zone.LastRedemptionRate)
 	k.Logger(ctx).Info("Current redemption rate", "rate", zone.RedemptionRate)
-	k.Logger(ctx).Info("New redemption rate", "rate", ratio, "supply", k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount, "lv", k.GetDelegatedAmount(ctx, &zone).Amount.Add(epochRewards).Add(delegationsInProcess))
+	k.Logger(ctx).Info("New redemption rate", "rate", ratio, "supply", k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount, "lv", k.GetDelegatedAmount(ctx, zone).Amount.Add(epochRewards).Add(delegationsInProcess))
 
 	// soft cap redemption rate, instead of panicking.
 	delta := ratio.Quo(zone.RedemptionRate)
@@ -507,23 +510,23 @@ func (k *Keeper) UpdateRedemptionRate(ctx sdk.Context, zone types.Zone, epochRew
 
 	zone.LastRedemptionRate = zone.RedemptionRate
 	zone.RedemptionRate = ratio
-	k.SetZone(ctx, &zone)
+	k.SetZone(ctx, zone)
 }
 
-func (k *Keeper) OverrideRedemptionRateNoCap(ctx sdk.Context, zone types.Zone) {
+func (k *Keeper) OverrideRedemptionRateNoCap(ctx sdk.Context, zone *types.Zone) {
 	ratio, _ := k.GetRatio(ctx, zone, sdk.ZeroInt())
 	k.Logger(ctx).Info("Last redemption rate", "rate", zone.LastRedemptionRate)
 	k.Logger(ctx).Info("Current redemption rate", "rate", zone.RedemptionRate)
-	k.Logger(ctx).Info("New redemption rate", "rate", ratio, "supply", k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount, "lv", k.GetDelegatedAmount(ctx, &zone).Amount)
+	k.Logger(ctx).Info("New redemption rate", "rate", ratio, "supply", k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount, "lv", k.GetDelegatedAmount(ctx, zone).Amount)
 
 	zone.RedemptionRate = ratio
-	k.SetZone(ctx, &zone)
+	k.SetZone(ctx, zone)
 }
 
-func (k *Keeper) GetRatio(ctx sdk.Context, zone types.Zone, epochRewards math.Int) (sdk.Dec, bool) {
+func (k *Keeper) GetRatio(ctx sdk.Context, zone *types.Zone, epochRewards sdkmath.Int) (sdk.Dec, bool) {
 	// native asset amount
-	nativeAssetAmount := k.GetDelegatedAmount(ctx, &zone).Amount
-	nativeAssetUnbondingAmount := k.GetUnbondingAmount(ctx, &zone).Amount
+	nativeAssetAmount := k.GetDelegatedAmount(ctx, zone).Amount
+	nativeAssetUnbondingAmount := k.GetUnbondingAmount(ctx, zone).Amount
 
 	// qAsset amount
 	qAssetAmount := k.BankKeeper.GetSupply(ctx, zone.LocalDenom).Amount
@@ -538,13 +541,13 @@ func (k *Keeper) GetRatio(ctx sdk.Context, zone types.Zone, epochRewards math.In
 	return sdk.NewDecFromInt(nativeAssetAmount.Add(epochRewards).Add(nativeAssetUnbondingAmount)).Quo(sdk.NewDecFromInt(qAssetAmount)), false
 }
 
-func (k *Keeper) Rebalance(ctx sdk.Context, zone types.Zone, epochNumber int64) error {
-	currentAllocations, currentSum, currentLocked := k.GetDelegationMap(ctx, &zone)
+func (k *Keeper) Rebalance(ctx sdk.Context, zone *types.Zone, epochNumber int64) error {
+	currentAllocations, currentSum, currentLocked := k.GetDelegationMap(ctx, zone)
 	targetAllocations := zone.GetAggregateIntentOrDefault()
-	rebalances := DetermineAllocationsForRebalancing(currentAllocations, currentLocked, currentSum, targetAllocations, k.ZoneRedelegationRecords(ctx, zone.ChainId), k.Logger(ctx))
+	rebalances := types.DetermineAllocationsForRebalancing(currentAllocations, currentLocked, currentSum, targetAllocations, k.ZoneRedelegationRecords(ctx, zone.ChainId), k.Logger(ctx))
 	msgs := make([]sdk.Msg, 0)
 	for _, rebalance := range rebalances {
-		msgs = append(msgs, &stakingTypes.MsgBeginRedelegate{DelegatorAddress: zone.DelegationAddress.Address, ValidatorSrcAddress: rebalance.Source, ValidatorDstAddress: rebalance.Target, Amount: sdk.NewCoin(zone.BaseDenom, rebalance.Amount)})
+		msgs = append(msgs, &stakingtypes.MsgBeginRedelegate{DelegatorAddress: zone.DelegationAddress.Address, ValidatorSrcAddress: rebalance.Source, ValidatorDstAddress: rebalance.Target, Amount: sdk.NewCoin(zone.BaseDenom, rebalance.Amount)})
 		k.SetRedelegationRecord(ctx, types.RedelegationRecord{
 			ChainId:     zone.ChainId,
 			EpochNumber: epochNumber,
@@ -561,153 +564,44 @@ func (k *Keeper) Rebalance(ctx sdk.Context, zone types.Zone, epochNumber int64) 
 	return k.SubmitTx(ctx, msgs, zone.DelegationAddress, fmt.Sprintf("rebalance/%d", epochNumber))
 }
 
-type RebalanceTarget struct {
-	Amount math.Int
-	Source string
-	Target string
-}
-
-func DetermineAllocationsForRebalancing(currentAllocations map[string]math.Int, currentLocked map[string]bool, currentSum math.Int, targetAllocations types.ValidatorIntents, existingRedelegations []types.RedelegationRecord, log log.Logger) []RebalanceTarget {
-	out := make([]RebalanceTarget, 0)
-	deltas := CalculateDeltas(currentAllocations, currentSum, targetAllocations)
-
-	wantToRebalance := sdk.ZeroInt()
-	canRebalanceFrom := sdk.ZeroInt()
-
-	totalLocked := int64(0)
-	lockedPerValidator := map[string]int64{}
-	for _, redelegation := range existingRedelegations {
-		totalLocked += redelegation.Amount
-		thisLocked, found := lockedPerValidator[redelegation.Destination]
-		if !found {
-			thisLocked = 0
-		}
-		lockedPerValidator[redelegation.Destination] = thisLocked + redelegation.Amount
+// UnmarshalValidatorResponse attempts to umarshal  a byte slice into a QueryValidatorsResponse.
+func (k Keeper) UnmarshalValidatorResponse(data []byte) (stakingtypes.QueryValidatorsResponse, error) {
+	validatorsRes := stakingtypes.QueryValidatorsResponse{}
+	if len(data) == 0 {
+		return validatorsRes, errors.New("attempted to unmarshal zero length byte slice (8)")
 	}
-	for _, valoper := range utils.Keys(currentAllocations) {
-		// if validator already has a redelegation _to_ it, we can no longer redelegate _from_ it (transitive redelegations)
-		// remove _locked_ amount from lpv and total locked for purposes of rebalancing.
-		if currentLocked[valoper] {
-			thisLocked, found := lockedPerValidator[valoper]
-			if !found {
-				thisLocked = 0
-			}
-			totalLocked = totalLocked - thisLocked + currentAllocations[valoper].Int64()
-			lockedPerValidator[valoper] = currentAllocations[valoper].Int64()
-		}
-	}
-
-	// TODO: make these params
-	maxCanRebalanceTotal := currentSum.Sub(math.NewInt(totalLocked)).Quo(sdk.NewInt(2))
-	maxCanRebalance := math.MinInt(maxCanRebalanceTotal, currentSum.Quo(sdk.NewInt(7)))
-	if log != nil {
-		log.Debug("Rebalancing", "totalLocked", totalLocked, "lockedPerValidator", lockedPerValidator, "canRebalanceTotal", maxCanRebalanceTotal, "canRebalanceEpoch", maxCanRebalance)
-	}
-
-	// deltas are sorted in CalculateDeltas; don't re-sort.
-	for _, delta := range deltas {
-		switch {
-		case delta.Weight.IsZero():
-			// do nothing
-		case delta.Weight.IsPositive():
-			// if delta > current value - locked value, truncate, as we cannot rebalance locked tokens.
-			wantToRebalance = wantToRebalance.Add(delta.Weight.TruncateInt())
-		case delta.Weight.IsNegative():
-			if delta.Weight.Abs().GT(sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(math.NewInt(lockedPerValidator[delta.ValoperAddress])))) {
-				delta.Weight = sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(math.NewInt(lockedPerValidator[delta.ValoperAddress]))).Neg()
-				if log != nil {
-					log.Debug("Truncated delta due to locked tokens", "valoper", delta.ValoperAddress, "delta", delta.Weight.Abs())
-				}
-			}
-			canRebalanceFrom = canRebalanceFrom.Add(delta.Weight.Abs().TruncateInt())
-		}
-	}
-
-	toRebalance := sdk.MinInt(sdk.MinInt(wantToRebalance, canRebalanceFrom), maxCanRebalance)
-
-	if toRebalance.Equal(math.ZeroInt()) {
-		if log != nil {
-			log.Debug("No rebalancing this epoch")
-		}
-		return []RebalanceTarget{}
-	}
-	if log != nil {
-		log.Debug("Will rebalance this epoch", "amount", toRebalance)
-	}
-
-	tgtIdx := 0
-	srcIdx := len(deltas) - 1
-	for i := 0; toRebalance.GT(sdk.ZeroInt()); {
-		i++
-		if i > 20 {
-			break
-		}
-		src := deltas[srcIdx]
-		tgt := deltas[tgtIdx]
-		if src.ValoperAddress == tgt.ValoperAddress {
-			break
-		}
-		var amount math.Int
-		if src.Weight.Abs().TruncateInt().IsZero() { //nolint:gocritic
-			srcIdx--
-			continue
-		} else if src.Weight.Abs().TruncateInt().GT(toRebalance) { // amount == rebalance
-			amount = toRebalance
-		} else {
-			amount = src.Weight.Abs().TruncateInt()
-		}
-
-		if tgt.Weight.Abs().TruncateInt().IsZero() { //nolint:gocritic
-			tgtIdx++
-			continue
-		} else if tgt.Weight.Abs().TruncateInt().GT(toRebalance) {
-			// amount == amount!
-		} else {
-			amount = sdk.MinInt(amount, tgt.Weight.Abs().TruncateInt())
-		}
-		out = append(out, RebalanceTarget{Amount: amount, Target: tgt.ValoperAddress, Source: src.ValoperAddress})
-		deltas[srcIdx].Weight = src.Weight.Add(sdk.NewDecFromInt(amount))
-		deltas[tgtIdx].Weight = tgt.Weight.Sub(sdk.NewDecFromInt(amount))
-		toRebalance = toRebalance.Sub(amount)
-
-	}
-
-	// sort keys by relative value of delta
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Source < out[j].Source
-	})
-
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Target < out[j].Target
-	})
-
-	// sort keys by relative value of delta
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Amount.GT(out[j].Amount)
-	})
-
-	return out
-}
-
-func (k Keeper) EmitValsetRequery(ctx sdk.Context, connectionID string, chainID string) error {
-	query := stakingTypes.QueryValidatorsRequest{}
-	bz1, err := k.cdc.Marshal(&query)
+	err := k.cdc.Unmarshal(data, &validatorsRes)
 	if err != nil {
-		return err
+		return validatorsRes, err
 	}
 
-	period := int64(k.GetParam(ctx, types.KeyValidatorSetInterval))
+	return validatorsRes, nil
+}
 
-	k.ICQKeeper.MakeRequest(
-		ctx,
-		connectionID,
-		chainID,
-		"cosmos.staking.v1beta1.Query/Validators",
-		bz1,
-		sdk.NewInt(period),
-		types.ModuleName,
-		"valset",
-		0,
-	)
-	return nil
+// UnmarshalValidatorRequest attempts to umarshal  a byte slice into a QueryValidatorsRequest.
+func (k Keeper) UnmarshalValidatorRequest(data []byte) (stakingtypes.QueryValidatorsRequest, error) {
+	validatorsReq := stakingtypes.QueryValidatorsRequest{}
+	if len(data) == 0 {
+		return validatorsReq, errors.New("attempted to unmarshal zero length byte slice (8)")
+	}
+	err := k.cdc.Unmarshal(data, &validatorsReq)
+	if err != nil {
+		return validatorsReq, err
+	}
+
+	return validatorsReq, nil
+}
+
+// UnmarshalValidator attempts to umarshal  a byte slice into a Validator.
+func (k Keeper) UnmarshalValidator(data []byte) (stakingtypes.Validator, error) {
+	validator := stakingtypes.Validator{}
+	if len(data) == 0 {
+		return validator, errors.New("attempted to unmarshal zero length byte slice (9)")
+	}
+	err := k.cdc.Unmarshal(data, &validator)
+	if err != nil {
+		return validator, err
+	}
+
+	return validator, nil
 }

--- a/x/interchainstaking/keeper/keeper_test.go
+++ b/x/interchainstaking/keeper/keeper_test.go
@@ -109,7 +109,7 @@ func (suite *KeeperTestSuite) setupTestZones() {
 		// refetch the zone for each validator, else we end up with an empty valset each time!
 		zone, found := qApp.InterchainstakingKeeper.GetZone(suite.chainA.GetContext(), suite.chainB.ChainID)
 		suite.Require().True(found)
-		suite.Require().NoError(icskeeper.SetValidatorForZone(&qApp.InterchainstakingKeeper, suite.chainA.GetContext(), zone, app.DefaultConfig().Codec.MustMarshal(&val)))
+		suite.Require().NoError(qApp.InterchainstakingKeeper.SetValidatorForZone(suite.chainA.GetContext(), &zone, app.DefaultConfig().Codec.MustMarshal(&val)))
 	}
 
 	suite.coordinator.CommitNBlocks(suite.chainA, 2)
@@ -488,7 +488,7 @@ func (s *KeeperTestSuite) TestGetRatio() {
 
 			qapp.MintKeeper.MintCoins(ctx, sdk.NewCoins(sdk.NewCoin(zone.LocalDenom, tt.supply)))
 
-			actual, isZero := icsKeeper.GetRatio(ctx, zone, sdk.ZeroInt())
+			actual, isZero := icsKeeper.GetRatio(ctx, &zone, sdk.ZeroInt())
 			s.Require().Equal(tt.supply.IsZero(), isZero)
 			s.Require().Equal(tt.expected, actual)
 		})
@@ -518,7 +518,7 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRate() {
 
 	// no change!
 	s.Require().Equal(sdk.OneDec(), zone.RedemptionRate)
-	icsKeeper.UpdateRedemptionRate(ctx, zone, sdk.ZeroInt())
+	icsKeeper.UpdateRedemptionRate(ctx, &zone, sdk.ZeroInt())
 
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
@@ -526,7 +526,7 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRate() {
 
 	// add 1%
 	s.Require().Equal(sdk.OneDec(), zone.RedemptionRate)
-	icsKeeper.UpdateRedemptionRate(ctx, zone, sdk.NewInt(30))
+	icsKeeper.UpdateRedemptionRate(ctx, &zone, sdk.NewInt(30))
 	delegationA.Amount.Amount = delegationA.Amount.Amount.AddRaw(10)
 	delegationB.Amount.Amount = delegationB.Amount.Amount.AddRaw(10)
 	delegationC.Amount.Amount = delegationC.Amount.Amount.AddRaw(10)
@@ -539,7 +539,7 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRate() {
 	s.Require().Equal(sdk.NewDecWithPrec(101, 2), zone.RedemptionRate)
 
 	// add >2%; cap at 2%
-	icsKeeper.UpdateRedemptionRate(ctx, zone, sdk.NewInt(500))
+	icsKeeper.UpdateRedemptionRate(ctx, &zone, sdk.NewInt(500))
 	delegationA.Amount.Amount = delegationA.Amount.Amount.AddRaw(166)
 	delegationB.Amount.Amount = delegationB.Amount.Amount.AddRaw(167)
 	delegationC.Amount.Amount = delegationC.Amount.Amount.AddRaw(167)
@@ -552,7 +552,7 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRate() {
 	s.Require().Equal(sdk.NewDecWithPrec(10302, 4), zone.RedemptionRate)
 
 	// add nothing, still cap at 2%
-	icsKeeper.UpdateRedemptionRate(ctx, zone, sdk.ZeroInt())
+	icsKeeper.UpdateRedemptionRate(ctx, &zone, sdk.ZeroInt())
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
 	// should be capped at 2% increase. (1.01*1.02*1.02 == 1.050804)
@@ -566,7 +566,7 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRate() {
 	icsKeeper.SetDelegation(ctx, &zone, delegationC)
 
 	// remove > 5%, cap at -5%
-	icsKeeper.UpdateRedemptionRate(ctx, zone, sdk.ZeroInt())
+	icsKeeper.UpdateRedemptionRate(ctx, &zone, sdk.ZeroInt())
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
 
@@ -596,7 +596,7 @@ func (s *KeeperTestSuite) TestOverrideRedemptionRateNoCap() {
 
 	// no change!
 	s.Require().Equal(sdk.OneDec(), zone.RedemptionRate)
-	icsKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+	icsKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
@@ -609,7 +609,7 @@ func (s *KeeperTestSuite) TestOverrideRedemptionRateNoCap() {
 	icsKeeper.SetDelegation(ctx, &zone, delegationA)
 	icsKeeper.SetDelegation(ctx, &zone, delegationB)
 	icsKeeper.SetDelegation(ctx, &zone, delegationC)
-	icsKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+	icsKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
@@ -622,14 +622,14 @@ func (s *KeeperTestSuite) TestOverrideRedemptionRateNoCap() {
 	icsKeeper.SetDelegation(ctx, &zone, delegationA)
 	icsKeeper.SetDelegation(ctx, &zone, delegationB)
 	icsKeeper.SetDelegation(ctx, &zone, delegationC)
-	icsKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+	icsKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
 	s.Require().Equal(sdk.NewDecWithPrec(1176666666666666667, 18), zone.RedemptionRate)
 
 	// add nothing, no change
-	icsKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+	icsKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
 	s.Require().Equal(sdk.NewDecWithPrec(1176666666666666667, 18), zone.RedemptionRate)
@@ -640,7 +640,7 @@ func (s *KeeperTestSuite) TestOverrideRedemptionRateNoCap() {
 	icsKeeper.SetDelegation(ctx, &zone, delegationA)
 	icsKeeper.SetDelegation(ctx, &zone, delegationB)
 	icsKeeper.SetDelegation(ctx, &zone, delegationC)
-	icsKeeper.OverrideRedemptionRateNoCap(ctx, zone)
+	icsKeeper.OverrideRedemptionRateNoCap(ctx, &zone)
 	zone, found = icsKeeper.GetZone(ctx, s.chainB.ChainID)
 	s.Require().True(found)
 

--- a/x/interchainstaking/keeper/keeper_test.go
+++ b/x/interchainstaking/keeper/keeper_test.go
@@ -91,7 +91,7 @@ func (suite *KeeperTestSuite) setupTestZones() {
 	qApp := suite.GetQuicksilverApp(suite.chainA)
 	ctx := suite.chainA.GetContext()
 
-	err := icskeeper.HandleRegisterZoneProposal(ctx, qApp.InterchainstakingKeeper, proposal)
+	err := qApp.InterchainstakingKeeper.HandleRegisterZoneProposal(ctx, proposal)
 	suite.Require().NoError(err)
 
 	zone, found := qApp.InterchainstakingKeeper.GetZone(suite.chainA.GetContext(), suite.chainB.ChainID)

--- a/x/interchainstaking/keeper/msg_server.go
+++ b/x/interchainstaking/keeper/msg_server.go
@@ -56,9 +56,9 @@ func (k msgServer) RequestRedemption(goCtx context.Context, msg *types.MsgReques
 
 	var zone *types.Zone
 
-	k.IterateZones(ctx, func(_ int64, thisZone types.Zone) bool {
+	k.IterateZones(ctx, func(_ int64, thisZone *types.Zone) bool {
 		if thisZone.LocalDenom == msg.Value.GetDenom() {
-			zone = &thisZone
+			zone = thisZone
 			return true
 		}
 		return false
@@ -110,11 +110,11 @@ func (k msgServer) RequestRedemption(goCtx context.Context, msg *types.MsgReques
 	}
 
 	if zone.LiquidityModule {
-		if err = k.processRedemptionForLsm(ctx, *zone, sender, msg.DestinationAddress, nativeTokens, msg.Value, hashString); err != nil {
+		if err = k.processRedemptionForLsm(ctx, zone, sender, msg.DestinationAddress, nativeTokens, msg.Value, hashString); err != nil {
 			return nil, err
 		}
 	} else {
-		if err = k.queueRedemption(ctx, *zone, sender, msg.DestinationAddress, nativeTokens, msg.Value, hashString); err != nil {
+		if err = k.queueRedemption(ctx, zone, sender, msg.DestinationAddress, nativeTokens, msg.Value, hashString); err != nil {
 			return nil, err
 		}
 	}
@@ -161,7 +161,7 @@ func (k msgServer) SignalIntent(goCtx context.Context, msg *types.MsgSignalInten
 		Intents:   intents,
 	}
 
-	k.SetIntent(ctx, zone, intent, false)
+	k.SetIntent(ctx, &zone, intent, false)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(

--- a/x/interchainstaking/keeper/msg_server.go
+++ b/x/interchainstaking/keeper/msg_server.go
@@ -178,7 +178,7 @@ func (k msgServer) SignalIntent(goCtx context.Context, msg *types.MsgSignalInten
 	return &types.MsgSignalIntentResponse{}, nil
 }
 
-// GovReopenChannel reopens an ICA channel
+// GovReopenChannel reopens an ICA channel.
 func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReopenChannel) (*types.MsgGovReopenChannelResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -224,7 +224,7 @@ func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReop
 	return &types.MsgGovReopenChannelResponse{}, nil
 }
 
-// GovReopenChannel reopens an ICA channel
+// GovCloseChannel closes an ICA channel.
 func (k msgServer) GovCloseChannel(goCtx context.Context, msg *types.MsgGovCloseChannel) (*types.MsgGovCloseChannelResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/interchainstaking/keeper/msg_server_test.go
+++ b/x/interchainstaking/keeper/msg_server_test.go
@@ -527,7 +527,7 @@ func (s *KeeperTestSuite) TestSignalIntent() {
 			zone, found := icsKeeper.GetZone(s.chainA.GetContext(), s.chainB.ChainID)
 			s.Require().True(found)
 
-			intent, found := icsKeeper.GetIntent(s.chainA.GetContext(), zone, testAddress, false)
+			intent, found := icsKeeper.GetIntent(s.chainA.GetContext(), &zone, testAddress, false)
 			s.Require().True(found)
 			intents := intent.GetIntents()
 

--- a/x/interchainstaking/keeper/proposal_handler.go
+++ b/x/interchainstaking/keeper/proposal_handler.go
@@ -19,7 +19,7 @@ import (
 )
 
 // HandleRegisterZoneProposal is a handler for executing a passed community spend proposal
-func HandleRegisterZoneProposal(ctx sdk.Context, k Keeper, p *types.RegisterZoneProposal) error {
+func (k *Keeper) HandleRegisterZoneProposal(ctx sdk.Context, p *types.RegisterZoneProposal) error {
 	// get chain id from connection
 	chainID, err := k.GetChainID(ctx, p.ConnectionId)
 	if err != nil {
@@ -114,7 +114,7 @@ func HandleRegisterZoneProposal(ctx sdk.Context, k Keeper, p *types.RegisterZone
 	return nil
 }
 
-func (k Keeper) registerInterchainAccount(ctx sdk.Context, connectionID string, portOwner string) error {
+func (k *Keeper) registerInterchainAccount(ctx sdk.Context, connectionID string, portOwner string) error {
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, connectionID, portOwner, ""); err != nil { // todo: add version
 		return err
 	}
@@ -125,7 +125,7 @@ func (k Keeper) registerInterchainAccount(ctx sdk.Context, connectionID string, 
 }
 
 // HandleUpdateZoneProposal is a handler for executing a passed community spend proposal
-func HandleUpdateZoneProposal(ctx sdk.Context, k Keeper, p *types.UpdateZoneProposal) error {
+func (k *Keeper) HandleUpdateZoneProposal(ctx sdk.Context, p *types.UpdateZoneProposal) error {
 	zone, found := k.GetZone(ctx, p.ChainId)
 	if !found {
 		err := fmt.Errorf("unable to get registered zone for chain id: %s", p.ChainId)

--- a/x/interchainstaking/keeper/receipt.go
+++ b/x/interchainstaking/keeper/receipt.go
@@ -24,7 +24,7 @@ const (
 	ICAMsgChunkSize = 5
 )
 
-func (k Keeper) HandleReceiptTransaction(ctx sdk.Context, txr *sdk.TxResponse, txn *tx.Tx, zone types.Zone) error {
+func (k Keeper) HandleReceiptTransaction(ctx sdk.Context, txr *sdk.TxResponse, txn *tx.Tx, zone *types.Zone) error {
 	k.Logger(ctx).Info("Deposit receipt.", "ischeck", ctx.IsCheckTx(), "isrecheck", ctx.IsReCheckTx())
 	hash := txr.TxHash
 	memo := txn.Body.Memo
@@ -109,7 +109,7 @@ func attributesToMap(attrs []abcitypes.EventAttribute) map[string]string {
 	return out
 }
 
-func (k *Keeper) MintQAsset(ctx sdk.Context, sender sdk.AccAddress, senderAddress string, zone types.Zone, inCoins sdk.Coins, returnToSender bool) error {
+func (k *Keeper) MintQAsset(ctx sdk.Context, sender sdk.AccAddress, senderAddress string, zone *types.Zone, inCoins sdk.Coins, returnToSender bool) error {
 	if zone.RedemptionRate.IsZero() {
 		return errors.New("zero redemption rate")
 	}
@@ -153,7 +153,7 @@ func (k *Keeper) MintQAsset(ctx sdk.Context, sender sdk.AccAddress, senderAddres
 	return err
 }
 
-func (k *Keeper) TransferToDelegate(ctx sdk.Context, zone types.Zone, coins sdk.Coins, memo string) error {
+func (k *Keeper) TransferToDelegate(ctx sdk.Context, zone *types.Zone, coins sdk.Coins, memo string) error {
 	msg := &bankTypes.MsgSend{FromAddress: zone.DepositAddress.GetAddress(), ToAddress: zone.DelegationAddress.GetAddress(), Amount: coins}
 	return k.SubmitTx(ctx, []sdk.Msg{msg}, zone.DepositAddress, memo)
 }
@@ -216,7 +216,7 @@ func (k *Keeper) SubmitTx(ctx sdk.Context, msgs []sdk.Msg, account *types.ICAAcc
 
 // ---------------------------------------------------------------
 
-func (k Keeper) NewReceipt(ctx sdk.Context, zone types.Zone, sender string, txhash string, amount sdk.Coins) *types.Receipt {
+func (k Keeper) NewReceipt(ctx sdk.Context, zone *types.Zone, sender string, txhash string, amount sdk.Coins) *types.Receipt {
 	t := ctx.BlockTime()
 	return &types.Receipt{ChainId: zone.ChainId, Sender: sender, Txhash: txhash, Amount: amount, FirstSeen: &t}
 }

--- a/x/interchainstaking/keeper/redelegation_record.go
+++ b/x/interchainstaking/keeper/redelegation_record.go
@@ -1,26 +1,17 @@
 package keeper
 
 import (
-	"encoding/binary"
-
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-// unbondigng records are keyed by chainId, validator and epoch, as they must be unique with regard to this triple.
-func GetRedelegationKey(chainID string, source string, destination string, epochNumber int64) []byte {
-	epochBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(epochBytes, uint64(epochNumber))
-	return append(types.KeyPrefixRedelegationRecord, append(append([]byte(chainID), []byte(source+destination)...), epochBytes...)...)
-}
-
 // GetRedelegationRecord returns Redelegation record info by zone, validator and epoch
-func (k Keeper) GetRedelegationRecord(ctx sdk.Context, chainID string, source string, destination string, epochNumber int64) (types.RedelegationRecord, bool) {
+func (k *Keeper) GetRedelegationRecord(ctx sdk.Context, chainID string, source string, destination string, epochNumber int64) (types.RedelegationRecord, bool) {
 	record := types.RedelegationRecord{}
 
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), nil)
-	bz := store.Get(GetRedelegationKey(chainID, source, destination, epochNumber))
+	bz := store.Get(types.GetRedelegationKey(chainID, source, destination, epochNumber))
 	if bz == nil {
 		return record, false
 	}
@@ -29,26 +20,26 @@ func (k Keeper) GetRedelegationRecord(ctx sdk.Context, chainID string, source st
 }
 
 // SetRedelegationRecord store the Redelegation record
-func (k Keeper) SetRedelegationRecord(ctx sdk.Context, record types.RedelegationRecord) {
+func (k *Keeper) SetRedelegationRecord(ctx sdk.Context, record types.RedelegationRecord) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), nil)
 	bz := k.cdc.MustMarshal(&record)
-	store.Set(GetRedelegationKey(record.ChainId, record.Source, record.Destination, record.EpochNumber), bz)
+	store.Set(types.GetRedelegationKey(record.ChainId, record.Source, record.Destination, record.EpochNumber), bz)
 }
 
 // DeleteRedelegationRecord deletes Redelegation record
-func (k Keeper) DeleteRedelegationRecord(ctx sdk.Context, chainID string, source string, destination string, epochNumber int64) {
+func (k *Keeper) DeleteRedelegationRecord(ctx sdk.Context, chainID string, source string, destination string, epochNumber int64) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), nil)
-	store.Delete(GetRedelegationKey(chainID, source, destination, epochNumber))
+	store.Delete(types.GetRedelegationKey(chainID, source, destination, epochNumber))
 }
 
-// DeleteRedelegationRecord deletes Redelegation record
-func (k Keeper) DeleteRedelegationRecordByKey(ctx sdk.Context, key []byte) {
+// DeleteRedelegationRecordByKey deletes Redelegation record
+func (k *Keeper) DeleteRedelegationRecordByKey(ctx sdk.Context, key []byte) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), nil)
 	store.Delete(key)
 }
 
 // IteratePrefixedRedelegationRecords iterate through all records with given prefix
-func (k Keeper) IteratePrefixedRedelegationRecords(ctx sdk.Context, prefixBytes []byte, fn func(index int64, key []byte, record types.RedelegationRecord) (stop bool)) {
+func (k *Keeper) IteratePrefixedRedelegationRecords(ctx sdk.Context, prefixBytes []byte, fn func(index int64, key []byte, record types.RedelegationRecord) (stop bool)) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixRedelegationRecord)
 
 	iterator := sdk.KVStorePrefixIterator(store, prefixBytes)
@@ -70,12 +61,12 @@ func (k Keeper) IteratePrefixedRedelegationRecords(ctx sdk.Context, prefixBytes 
 }
 
 // IterateRedelegationRecords iterate through all records
-func (k Keeper) IterateRedelegationRecords(ctx sdk.Context, fn func(index int64, key []byte, record types.RedelegationRecord) (stop bool)) {
+func (k *Keeper) IterateRedelegationRecords(ctx sdk.Context, fn func(index int64, key []byte, record types.RedelegationRecord) (stop bool)) {
 	k.IteratePrefixedRedelegationRecords(ctx, nil, fn)
 }
 
 // AllRedelegationRecords returns every record in the store for the specified zone
-func (k Keeper) AllRedelegationRecords(ctx sdk.Context) []types.RedelegationRecord {
+func (k *Keeper) AllRedelegationRecords(ctx sdk.Context) []types.RedelegationRecord {
 	records := []types.RedelegationRecord{}
 	k.IterateRedelegationRecords(ctx, func(_ int64, _ []byte, record types.RedelegationRecord) (stop bool) {
 		records = append(records, record)
@@ -85,7 +76,7 @@ func (k Keeper) AllRedelegationRecords(ctx sdk.Context) []types.RedelegationReco
 }
 
 // ZoneRedelegationRecords returns every record in the store for the specified zone
-func (k Keeper) ZoneRedelegationRecords(ctx sdk.Context, chainID string) []types.RedelegationRecord {
+func (k *Keeper) ZoneRedelegationRecords(ctx sdk.Context, chainID string) []types.RedelegationRecord {
 	records := []types.RedelegationRecord{}
 	k.IteratePrefixedRedelegationRecords(ctx, []byte(chainID), func(_ int64, _ []byte, record types.RedelegationRecord) (stop bool) {
 		records = append(records, record)

--- a/x/interchainstaking/keeper/redemptions.go
+++ b/x/interchainstaking/keeper/redemptions.go
@@ -15,7 +15,7 @@ import (
 )
 
 // processRedemptionForLsm will determine based on user intent, the tokens to return to the user, generate Redeem message and send them.
-func (k *Keeper) processRedemptionForLsm(ctx sdk.Context, zone types.Zone, sender sdk.AccAddress, destination string, nativeTokens math.Int, burnAmount sdk.Coin, hash string) error {
+func (k *Keeper) processRedemptionForLsm(ctx sdk.Context, zone *types.Zone, sender sdk.AccAddress, destination string, nativeTokens math.Int, burnAmount sdk.Coin, hash string) error {
 	intent, found := k.GetIntent(ctx, zone, sender.String(), false)
 	// msgs is slice of MsgTokenizeShares, so we can handle dust allocation later.
 	msgs := make([]*lsmstakingtypes.MsgTokenizeShares, 0)
@@ -28,7 +28,7 @@ func (k *Keeper) processRedemptionForLsm(ctx sdk.Context, zone types.Zone, sende
 	outstanding := nativeTokens
 	distribution := make(map[string]uint64, 0)
 
-	availablePerValidator, _ := k.GetUnlockedTokensForZone(ctx, &zone)
+	availablePerValidator, _ := k.GetUnlockedTokensForZone(ctx, zone)
 
 	for _, intent := range intents.Sort() {
 		thisAmount := intent.Weight.MulInt(nativeTokens).TruncateInt()
@@ -63,7 +63,7 @@ func (k *Keeper) processRedemptionForLsm(ctx sdk.Context, zone types.Zone, sende
 // queueRedemption will determine based on zone intent, the tokens to unbond, and add a withdrawal record with status QUEUED.
 func (k *Keeper) queueRedemption(
 	ctx sdk.Context,
-	zone types.Zone,
+	zone *types.Zone,
 	sender sdk.AccAddress,
 	destination string,
 	nativeTokens math.Int,
@@ -117,7 +117,7 @@ func (k *Keeper) GetUnlockedTokensForZone(ctx sdk.Context, zone *types.Zone) (ma
 	return availablePerValidator, total
 }
 
-// handle queued unbondings is called once per epoch to aggregate all queued unbondings into
+// HandleQueuedUnbondings is called once per epoch to aggregate all queued unbondings into
 // a single unbond transaction per delegation.
 func (k *Keeper) HandleQueuedUnbondings(ctx sdk.Context, zone *types.Zone, epoch int64) error {
 	// out here will only ever be in native bond denom
@@ -249,130 +249,10 @@ func (k *Keeper) GCCompletedUnbondings(ctx sdk.Context, zone *types.Zone) error 
 	return err
 }
 
-func (k Keeper) DeterminePlanForUndelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) map[string]math.Int {
+func (k *Keeper) DeterminePlanForUndelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) map[string]math.Int {
 	currentAllocations, currentSum, _ := k.GetDelegationMap(ctx, zone)
 	availablePerValidator, _ := k.GetUnlockedTokensForZone(ctx, zone)
 	targetAllocations := zone.GetAggregateIntentOrDefault()
-	allocations := DetermineAllocationsForUndelegation(currentAllocations, currentSum, targetAllocations, availablePerValidator, amount)
+	allocations := types.DetermineAllocationsForUndelegation(currentAllocations, currentSum, targetAllocations, availablePerValidator, amount)
 	return allocations
-}
-
-func DetermineAllocationsForUndelegation(currentAllocations map[string]math.Int, currentSum math.Int, targetAllocations types.ValidatorIntents, availablePerValidator map[string]math.Int, amount sdk.Coins) map[string]math.Int {
-	input := amount[0].Amount
-	deltas := CalculateDeltas(currentAllocations, currentSum.Sub(input), targetAllocations)
-	sum := sdk.ZeroInt()
-	outSum := sdk.ZeroInt()
-	outWeights := make(map[string]math.Int)
-
-	// deltas: +ve is below target; -ve is above target.
-
-	// q1: can we satisfy this unbonding using _just_ above target allocations.
-	// example:
-	// we have v1: 5000, v2: 1800; v3: 1200; v4: 1000 and targets of 50%, 20%, 15% and 5% respectively.
-	// deltas == 500, 0, -150, 550
-	// an unbonding of 300 should come from v1, v4 (as they has an excess of > unbond amount) _before_ touching anything else.
-
-	for idx := range deltas {
-		if deltas[idx].Weight.IsNegative() {
-			sum = sum.Add(deltas[idx].Weight.TruncateInt().Abs())
-		}
-	}
-
-	overAllocationSplit := sdk.MinInt(sum, input)
-	if !overAllocationSplit.IsZero() {
-		for idx := range deltas {
-			if deltas[idx].Weight.IsNegative() {
-				fmt.Println("trying to remove from overallocated", deltas[idx].ValoperAddress)
-				outWeights[deltas[idx].ValoperAddress] = deltas[idx].Weight.Quo(sdk.NewDecFromInt(sum)).Mul(sdk.NewDecFromInt(overAllocationSplit)).TruncateInt().Abs()
-				if outWeights[deltas[idx].ValoperAddress].GT(availablePerValidator[deltas[idx].ValoperAddress]) {
-					outWeights[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress]
-					availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
-				} else {
-					availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(outWeights[deltas[idx].ValoperAddress])
-				}
-				fmt.Println("removed from overallocated", outWeights[deltas[idx].ValoperAddress])
-				deltas[idx].Weight = deltas[idx].Weight.Add(sdk.NewDecFromInt(outWeights[deltas[idx].ValoperAddress]))
-				outSum = outSum.Add(outWeights[deltas[idx].ValoperAddress])
-			}
-		}
-	}
-	input = input.Sub(outSum)
-	if input.IsZero() {
-		return outWeights
-	}
-
-	maxValue := maxDeltas(deltas)
-	sum = sdk.ZeroInt()
-
-	// drop all deltas such that the maximum value is zero, and invert.
-	for idx := range deltas {
-		deltas[idx].Weight = deltas[idx].Weight.Sub(sdk.NewDecFromInt(maxValue)).Abs()
-		sum = sum.Add(deltas[idx].Weight.TruncateInt().Abs())
-
-	}
-
-	// unequalSplit is the portion of input that should be distributed in attempt to make targets == 0
-	unequalSplit := sdk.MinInt(sum, input)
-
-	if !unequalSplit.IsZero() {
-		for idx := range deltas {
-			allocation := deltas[idx].Weight.Quo(sdk.NewDecFromInt(sum)).Mul(sdk.NewDecFromInt(unequalSplit))
-			_, ok := availablePerValidator[deltas[idx].ValoperAddress]
-			if !ok {
-				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
-			}
-
-			if allocation.TruncateInt().GT(availablePerValidator[deltas[idx].ValoperAddress]) {
-				allocation = sdk.NewDecFromInt(availablePerValidator[deltas[idx].ValoperAddress])
-				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
-			} else {
-				availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(allocation.TruncateInt())
-			}
-
-			deltas[idx].Weight = deltas[idx].Weight.Sub(allocation)
-			value, ok := outWeights[deltas[idx].ValoperAddress]
-			if !ok {
-				value = sdk.ZeroInt()
-			}
-
-			outWeights[deltas[idx].ValoperAddress] = value.Add(allocation.TruncateInt())
-			outSum = outSum.Add(allocation.TruncateInt())
-			input = input.Sub(allocation.TruncateInt())
-		}
-	}
-
-	// equalSplit is the portion of input that should be distributed equally across all validators, once targets are met.
-
-	if !outSum.Equal(amount[0].Amount) {
-		each := sdk.NewDecFromInt(input).Quo(sdk.NewDec(int64(len(deltas))))
-		for idx := range deltas {
-			value, ok := outWeights[deltas[idx].ValoperAddress]
-			if !ok {
-				value = sdk.ZeroInt()
-			}
-			if each.TruncateInt().GT(availablePerValidator[deltas[idx].ValoperAddress]) {
-				each = sdk.NewDecFromInt(availablePerValidator[deltas[idx].ValoperAddress])
-				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
-			} else {
-				availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(each.TruncateInt())
-			}
-			outWeights[deltas[idx].ValoperAddress] = value.Add(each.TruncateInt())
-			outSum = outSum.Add(each.TruncateInt())
-			input = input.Sub(each.TruncateInt())
-		}
-	}
-
-	// dust is the portion of the input that was truncated in previous calculations; add this to the last validator in the list,
-	// which should be the biggest source. This will always be a small amount, and will count toward the delta calculations on the next run.
-	dust := amount[0].Amount.Sub(outSum)
-	for idx := len(deltas) - 1; idx >= 0; idx-- {
-		if dust.GT(availablePerValidator[deltas[idx].ValoperAddress]) {
-			continue
-		} else {
-			outWeights[deltas[idx].ValoperAddress] = outWeights[deltas[idx].ValoperAddress].Add(dust)
-			break
-		}
-	}
-
-	return outWeights
 }

--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -227,7 +227,7 @@ func (k *Keeper) EnsureWithdrawalAddresses(ctx sdk.Context, zone *types.Zone) er
 }
 
 // SetAccountBalanceForDenom sets the balance on an account for a given denominination.
-func SetAccountBalanceForDenom(k Keeper, ctx sdk.Context, zone *types.Zone, address string, coin sdk.Coin) error {
+func (k *Keeper) SetAccountBalanceForDenom(ctx sdk.Context, zone *types.Zone, address string, coin sdk.Coin) error {
 	// ? is this switch statement still required ?
 	// prior to callback we had no way to distinguish the originator
 	// with the query type in setAccountCb this is probably superfluous...

--- a/x/interchainstaking/keeper/zones_test.go
+++ b/x/interchainstaking/keeper/zones_test.go
@@ -98,8 +98,8 @@ func TestKeeperWithZonesRoundTrip(t *testing.T) {
 	require.Equal(t, nzones, len(indexToZone), "expecting unique nzones")
 
 	// 5.1. Invoke Iterate on zones.
-	gotZonesMapping := make(map[int64]types.Zone, nzones)
-	kpr.IterateZones(ctx, func(index int64, zone types.Zone) bool {
+	gotZonesMapping := make(map[int64]*types.Zone, nzones)
+	kpr.IterateZones(ctx, func(index int64, zone *types.Zone) bool {
 		gotZonesMapping[index] = zone
 		return false
 	})

--- a/x/interchainstaking/keeper/zones_test.go
+++ b/x/interchainstaking/keeper/zones_test.go
@@ -98,9 +98,9 @@ func TestKeeperWithZonesRoundTrip(t *testing.T) {
 	require.Equal(t, nzones, len(indexToZone), "expecting unique nzones")
 
 	// 5.1. Invoke Iterate on zones.
-	gotZonesMapping := make(map[int64]*types.Zone, nzones)
+	gotZonesMapping := make(map[int64]types.Zone, nzones)
 	kpr.IterateZones(ctx, func(index int64, zone *types.Zone) bool {
-		gotZonesMapping[index] = zone
+		gotZonesMapping[index] = *zone
 		return false
 	})
 

--- a/x/interchainstaking/module.go
+++ b/x/interchainstaking/module.go
@@ -142,7 +142,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	// WILL NOT expose gRPC services, and that QueryServer WILL expose gRPC
 	// services;
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), &am.keeper)
 }
 
 // RegisterInvariants registers the capability module's invariants.

--- a/x/interchainstaking/types/delegation.go
+++ b/x/interchainstaking/types/delegation.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	sdkmath "cosmossdk.io/math"
 	"errors"
 	"sort"
+
+	sdkmath "cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/interchainstaking/types/delegation.go
+++ b/x/interchainstaking/types/delegation.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"errors"
 	"sort"
 
@@ -114,4 +115,50 @@ func (vi ValidatorIntents) Normalize() ValidatorIntents {
 		out = append(out, &ValidatorIntent{ValoperAddress: i.ValoperAddress, Weight: i.Weight.Quo(total)})
 	}
 	return out.Sort()
+}
+
+func DetermineAllocationsForDelegation(currentAllocations map[string]sdkmath.Int, currentSum sdkmath.Int, targetAllocations ValidatorIntents, amount sdk.Coins) map[string]sdkmath.Int {
+	input := amount[0].Amount
+	deltas := CalculateDeltas(currentAllocations, currentSum, targetAllocations)
+	minValue := MinDeltas(deltas)
+	sum := sdk.ZeroInt()
+
+	// raise all deltas such that the minimum value is zero.
+	for idx := range deltas {
+		deltas[idx].Weight = deltas[idx].Weight.Add(sdk.NewDecFromInt(minValue.Abs()))
+		sum = sum.Add(deltas[idx].Weight.TruncateInt())
+	}
+
+	// unequalSplit is the portion of input that should be distributed in attempt to make targets == 0
+	unequalSplit := sdk.MinInt(sum, input)
+
+	if !unequalSplit.IsZero() {
+		for idx := range deltas {
+			deltas[idx].Weight = deltas[idx].Weight.QuoInt(sum).MulInt(unequalSplit)
+		}
+	}
+
+	// equalSplit is the portion of input that should be distributed equally across all validators, once targets are zero.
+	equalSplit := sdk.NewDecFromInt(input.Sub(unequalSplit))
+
+	if !equalSplit.IsZero() {
+		each := equalSplit.Quo(sdk.NewDec(int64(len(deltas))))
+		for idx := range deltas {
+			deltas[idx].Weight = deltas[idx].Weight.Add(each)
+		}
+	}
+
+	// dust is the portion of the input that was truncated in previous calculations; add this to the first validator in the list,
+	// once sorted alphabetically. This will always be a small amount, and will count toward the delta calculations on the next run.
+
+	outSum := sdk.ZeroInt()
+	outWeights := make(map[string]sdkmath.Int)
+	for _, delta := range deltas {
+		outWeights[delta.ValoperAddress] = delta.Weight.TruncateInt()
+		outSum = outSum.Add(delta.Weight.TruncateInt())
+	}
+	dust := input.Sub(outSum)
+	outWeights[deltas[0].ValoperAddress] = outWeights[deltas[0].ValoperAddress].Add(dust)
+
+	return outWeights
 }

--- a/x/interchainstaking/types/delegation_test.go
+++ b/x/interchainstaking/types/delegation_test.go
@@ -1,8 +1,10 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
@@ -49,4 +51,99 @@ func TestSetForValoper(t *testing.T) {
 
 	require.Equal(t, sdk.NewDecWithPrec(40, 1), intents.MustGetForValoper(v1).Weight)
 	require.Equal(t, sdk.NewDecWithPrec(60, 1), intents.MustGetForValoper(v2).Weight)
+}
+
+func TestDetermineAllocationsForDelegation(t *testing.T) {
+	// we auto generate the validator addresses in these tests. any dust gets allocated to the first validator in the list
+	// once sorted alphabetically on valoper.
+
+	val1 := utils.GenerateValAddressForTest()
+	val2 := utils.GenerateValAddressForTest()
+	val3 := utils.GenerateValAddressForTest()
+	val4 := utils.GenerateValAddressForTest()
+
+	tc := []struct {
+		current  map[string]sdkmath.Int
+		target   types.ValidatorIntents
+		inAmount sdk.Coins
+		expected map[string]sdkmath.Int
+		dust     sdkmath.Int
+	}{
+		{
+			current: map[string]sdkmath.Int{
+				val1.String(): sdk.NewInt(350000),
+				val2.String(): sdk.NewInt(650000),
+				val3.String(): sdk.NewInt(75000),
+			},
+			target: types.ValidatorIntents{
+				{ValoperAddress: val1.String(), Weight: sdk.NewDecWithPrec(30, 2)},
+				{ValoperAddress: val2.String(), Weight: sdk.NewDecWithPrec(63, 2)},
+				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(7, 2)},
+			},
+			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(50000))),
+			expected: map[string]sdkmath.Int{
+				val1.String(): sdk.ZeroInt(),
+				val2.String(): sdk.NewInt(33182),
+				val3.String(): sdk.NewInt(16818),
+			},
+		},
+		{
+			current: map[string]sdkmath.Int{
+				val1.String(): sdk.NewInt(52),
+				val2.String(): sdk.NewInt(24),
+				val3.String(): sdk.NewInt(20),
+				val4.String(): sdk.NewInt(4),
+			},
+			target: types.ValidatorIntents{
+				{ValoperAddress: val1.String(), Weight: sdk.NewDecWithPrec(50, 2)},
+				{ValoperAddress: val2.String(), Weight: sdk.NewDecWithPrec(25, 2)},
+				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(15, 2)},
+				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
+			},
+			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(20))),
+			expected: map[string]sdkmath.Int{
+				val4.String(): sdk.NewInt(11),
+				val3.String(): sdk.ZeroInt(),
+				val2.String(): sdk.NewInt(6),
+				val1.String(): sdk.NewInt(3),
+			},
+		},
+		{
+			current: map[string]sdkmath.Int{
+				val1.String(): sdk.NewInt(52),
+				val2.String(): sdk.NewInt(24),
+				val3.String(): sdk.NewInt(20),
+				val4.String(): sdk.NewInt(4),
+			},
+			target: types.ValidatorIntents{
+				{ValoperAddress: val1.String(), Weight: sdk.NewDecWithPrec(50, 2)},
+				{ValoperAddress: val2.String(), Weight: sdk.NewDecWithPrec(25, 2)},
+				{ValoperAddress: val3.String(), Weight: sdk.NewDecWithPrec(15, 2)},
+				{ValoperAddress: val4.String(), Weight: sdk.NewDecWithPrec(10, 2)},
+			},
+			inAmount: sdk.NewCoins(sdk.NewCoin("uqck", sdk.NewInt(50))),
+			expected: map[string]sdkmath.Int{
+				val4.String(): sdk.NewInt(20),
+				val2.String(): sdk.NewInt(13),
+				val1.String(): sdk.NewInt(10),
+				val3.String(): sdk.NewInt(7),
+			},
+		},
+	}
+
+	for caseNumber, val := range tc {
+		sum := sdkmath.ZeroInt()
+		for _, amount := range val.current {
+			sum = sum.Add(amount)
+		}
+		allocations := types.DetermineAllocationsForDelegation(val.current, sum, val.target, val.inAmount)
+		require.Equal(t, len(val.expected), len(allocations))
+		for valoper := range val.expected {
+			ex, ok := val.expected[valoper]
+			require.True(t, ok)
+			ac, ok := allocations[valoper]
+			require.True(t, ok)
+			require.True(t, ex.Equal(ac), fmt.Sprintf("Test Case #%d failed; allocations did not equal expected output - expected %s, got %s.", caseNumber, val.expected[valoper], allocations[valoper]))
+		}
+	}
 }

--- a/x/interchainstaking/types/keys.go
+++ b/x/interchainstaking/types/keys.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -85,24 +87,52 @@ func ParseStakingDelegationKey(key []byte) (sdk.AccAddress, sdk.ValAddress, erro
 	return delAddr, valAddr, nil
 }
 
-// gets the key for delegator bond with validator
+// GetDelegationKey gets the key for delegator bond with validator
 // VALUE: staking/Delegation
 func GetDelegationKey(zone *Zone, delAddr sdk.AccAddress, valAddr sdk.ValAddress) []byte {
 	return append(GetDelegationsKey(zone, delAddr), valAddr.Bytes()...)
 }
 
-// gets the prefix for a delegator for all validators
+// GetDelegationsKey gets the prefix for a delegator for all validators
 func GetDelegationsKey(zone *Zone, delAddr sdk.AccAddress) []byte {
 	return append(append(KeyPrefixDelegation, []byte(zone.ChainId)...), delAddr.Bytes()...)
 }
 
-// gets the key for delegator bond with validator
+// GetPerformanceDelegationKey gets the key for delegator bond with validator
 // VALUE: staking/Delegation
 func GetPerformanceDelegationKey(zone *Zone, delAddr sdk.AccAddress, valAddr sdk.ValAddress) []byte {
 	return append(GetPerformanceDelegationsKey(zone, delAddr), valAddr.Bytes()...)
 }
 
-// gets the prefix for a delegator for all validators
+// GetPerformanceDelegationsKey gets the prefix for a delegator for all validators
 func GetPerformanceDelegationsKey(zone *Zone, delAddr sdk.AccAddress) []byte {
 	return append(append(KeyPrefixPerformanceDelegation, []byte(zone.ChainId)...), delAddr.Bytes()...)
+}
+
+func GetReceiptKey(chainID string, txhash string) string {
+	return fmt.Sprintf("%s/%s", chainID, txhash)
+}
+
+// GetRedelegationKey gets the redelegation key.
+// Unbondigng records are keyed by chainId, validator and epoch, as they must be unique with regard to this triple.
+func GetRedelegationKey(chainID string, source string, destination string, epochNumber int64) []byte {
+	epochBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(epochBytes, uint64(epochNumber))
+	return append(KeyPrefixRedelegationRecord, append(append([]byte(chainID), []byte(source+destination)...), epochBytes...)...)
+}
+
+func GetWithdrawalKey(chainID string, status int32) []byte {
+	statusBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(statusBytes, uint64(status))
+	key := KeyPrefixWithdrawalRecord
+	key = append(key, append([]byte(chainID), statusBytes...)...)
+	return key
+}
+
+// GetUnbondingKey gets the unbonding key.
+// unbondigng records are keyed by chainId, validator and epoch, as they must be unique with regard to this triple.
+func GetUnbondingKey(chainID string, validator string, epochNumber int64) []byte {
+	epochBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(epochBytes, uint64(epochNumber))
+	return append(KeyPrefixUnbondingRecord, append(append([]byte(chainID), []byte(validator)...), epochBytes...)...)
 }

--- a/x/interchainstaking/types/keys.go
+++ b/x/interchainstaking/types/keys.go
@@ -84,3 +84,25 @@ func ParseStakingDelegationKey(key []byte) (sdk.AccAddress, sdk.ValAddress, erro
 	valAddr := key[3+delAddrLen : 3+delAddrLen+valAddrLen]
 	return delAddr, valAddr, nil
 }
+
+// gets the key for delegator bond with validator
+// VALUE: staking/Delegation
+func GetDelegationKey(zone *Zone, delAddr sdk.AccAddress, valAddr sdk.ValAddress) []byte {
+	return append(GetDelegationsKey(zone, delAddr), valAddr.Bytes()...)
+}
+
+// gets the prefix for a delegator for all validators
+func GetDelegationsKey(zone *Zone, delAddr sdk.AccAddress) []byte {
+	return append(append(KeyPrefixDelegation, []byte(zone.ChainId)...), delAddr.Bytes()...)
+}
+
+// gets the key for delegator bond with validator
+// VALUE: staking/Delegation
+func GetPerformanceDelegationKey(zone *Zone, delAddr sdk.AccAddress, valAddr sdk.ValAddress) []byte {
+	return append(GetPerformanceDelegationsKey(zone, delAddr), valAddr.Bytes()...)
+}
+
+// gets the prefix for a delegator for all validators
+func GetPerformanceDelegationsKey(zone *Zone, delAddr sdk.AccAddress) []byte {
+	return append(append(KeyPrefixPerformanceDelegation, []byte(zone.ChainId)...), delAddr.Bytes()...)
+}

--- a/x/interchainstaking/types/rebalance.go
+++ b/x/interchainstaking/types/rebalance.go
@@ -1,0 +1,217 @@
+package types
+
+import (
+	"math"
+	"sort"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/ingenuity-build/quicksilver/utils"
+)
+
+// CalculateDeltas determines, for the current delegations, in delta between actual allocations and the target intent.
+// Positive delta represents current allocation is below target, and vice versa.
+func CalculateDeltas(currentAllocations map[string]sdkmath.Int, currentSum sdkmath.Int, targetAllocations ValidatorIntents) ValidatorIntents {
+	deltas := make(ValidatorIntents, 0)
+
+	targetValopers := func(in ValidatorIntents) []string {
+		out := make([]string, 0, len(in))
+		for _, i := range in {
+			out = append(out, i.ValoperAddress)
+		}
+		return out
+	}(targetAllocations)
+
+	keySet := utils.Unique(append(targetValopers, utils.Keys(currentAllocations)...))
+	sort.Strings(keySet)
+	// for target allocations, raise the intent weight by the total delegated value to get target amount
+	for _, valoper := range keySet {
+		current, ok := currentAllocations[valoper]
+		if !ok {
+			current = sdk.ZeroInt()
+		}
+
+		target, ok := targetAllocations.GetForValoper(valoper)
+		if !ok {
+			target = &ValidatorIntent{ValoperAddress: valoper, Weight: sdk.ZeroDec()}
+		}
+		targetAmount := target.Weight.MulInt(currentSum).TruncateInt()
+		// diff between target and current allocations
+		// positive == below target, negative == above target
+		delta := targetAmount.Sub(current)
+		deltas = append(deltas, &ValidatorIntent{Weight: sdk.NewDecFromInt(delta), ValoperAddress: valoper})
+	}
+
+	// sort keys by relative value of delta
+	sort.SliceStable(deltas, func(i, j int) bool {
+		return deltas[i].ValoperAddress > deltas[j].ValoperAddress
+	})
+
+	// sort keys by relative value of delta
+	sort.SliceStable(deltas, func(i, j int) bool {
+		return deltas[i].Weight.GT(deltas[j].Weight)
+	})
+
+	return deltas
+}
+
+type RebalanceTarget struct {
+	Amount sdkmath.Int
+	Source string
+	Target string
+}
+
+func DetermineAllocationsForRebalancing(
+	currentAllocations map[string]sdkmath.Int,
+	currentLocked map[string]bool,
+	currentSum sdkmath.Int,
+	targetAllocations ValidatorIntents,
+	existingRedelegations []RedelegationRecord,
+	log log.Logger,
+) []RebalanceTarget {
+	out := make([]RebalanceTarget, 0)
+	deltas := CalculateDeltas(currentAllocations, currentSum, targetAllocations)
+
+	wantToRebalance := sdk.ZeroInt()
+	canRebalanceFrom := sdk.ZeroInt()
+
+	totalLocked := int64(0)
+	lockedPerValidator := map[string]int64{}
+	for _, redelegation := range existingRedelegations {
+		totalLocked += redelegation.Amount
+		thisLocked, found := lockedPerValidator[redelegation.Destination]
+		if !found {
+			thisLocked = 0
+		}
+		lockedPerValidator[redelegation.Destination] = thisLocked + redelegation.Amount
+	}
+	for _, valoper := range utils.Keys(currentAllocations) {
+		// if validator already has a redelegation _to_ it, we can no longer redelegate _from_ it (transitive redelegations)
+		// remove _locked_ amount from lpv and total locked for purposes of rebalancing.
+		if currentLocked[valoper] {
+			thisLocked, found := lockedPerValidator[valoper]
+			if !found {
+				thisLocked = 0
+			}
+			totalLocked = totalLocked - thisLocked + currentAllocations[valoper].Int64()
+			lockedPerValidator[valoper] = currentAllocations[valoper].Int64()
+		}
+	}
+
+	// TODO: make these params
+	maxCanRebalanceTotal := currentSum.Sub(sdkmath.NewInt(totalLocked)).Quo(sdk.NewInt(2))
+	maxCanRebalance := sdkmath.MinInt(maxCanRebalanceTotal, currentSum.Quo(sdk.NewInt(7)))
+	if log != nil {
+		log.Debug("Rebalancing", "totalLocked", totalLocked, "lockedPerValidator", lockedPerValidator, "canRebalanceTotal", maxCanRebalanceTotal, "canRebalanceEpoch", maxCanRebalance)
+	}
+
+	// deltas are sorted in CalculateDeltas; don't re-sort.
+	for _, delta := range deltas {
+		switch {
+		case delta.Weight.IsZero():
+			// do nothing
+		case delta.Weight.IsPositive():
+			// if delta > current value - locked value, truncate, as we cannot rebalance locked tokens.
+			wantToRebalance = wantToRebalance.Add(delta.Weight.TruncateInt())
+		case delta.Weight.IsNegative():
+			if delta.Weight.Abs().GT(sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(sdkmath.NewInt(lockedPerValidator[delta.ValoperAddress])))) {
+				delta.Weight = sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(sdkmath.NewInt(lockedPerValidator[delta.ValoperAddress]))).Neg()
+				if log != nil {
+					log.Debug("Truncated delta due to locked tokens", "valoper", delta.ValoperAddress, "delta", delta.Weight.Abs())
+				}
+			}
+			canRebalanceFrom = canRebalanceFrom.Add(delta.Weight.Abs().TruncateInt())
+		}
+	}
+
+	toRebalance := sdk.MinInt(sdk.MinInt(wantToRebalance, canRebalanceFrom), maxCanRebalance)
+
+	if toRebalance.Equal(sdkmath.ZeroInt()) {
+		if log != nil {
+			log.Debug("No rebalancing this epoch")
+		}
+		return []RebalanceTarget{}
+	}
+	if log != nil {
+		log.Debug("Will rebalance this epoch", "amount", toRebalance)
+	}
+
+	tgtIdx := 0
+	srcIdx := len(deltas) - 1
+	for i := 0; toRebalance.GT(sdk.ZeroInt()); {
+		i++
+		if i > 20 {
+			break
+		}
+		src := deltas[srcIdx]
+		tgt := deltas[tgtIdx]
+		if src.ValoperAddress == tgt.ValoperAddress {
+			break
+		}
+		var amount sdkmath.Int
+		if src.Weight.Abs().TruncateInt().IsZero() { //nolint:gocritic
+			srcIdx--
+			continue
+		} else if src.Weight.Abs().TruncateInt().GT(toRebalance) { // amount == rebalance
+			amount = toRebalance
+		} else {
+			amount = src.Weight.Abs().TruncateInt()
+		}
+
+		if tgt.Weight.Abs().TruncateInt().IsZero() { //nolint:gocritic
+			tgtIdx++
+			continue
+		} else if tgt.Weight.Abs().TruncateInt().GT(toRebalance) {
+			// amount == amount!
+		} else {
+			amount = sdk.MinInt(amount, tgt.Weight.Abs().TruncateInt())
+		}
+		out = append(out, RebalanceTarget{Amount: amount, Target: tgt.ValoperAddress, Source: src.ValoperAddress})
+		deltas[srcIdx].Weight = src.Weight.Add(sdk.NewDecFromInt(amount))
+		deltas[tgtIdx].Weight = tgt.Weight.Sub(sdk.NewDecFromInt(amount))
+		toRebalance = toRebalance.Sub(amount)
+
+	}
+
+	// sort keys by relative value of delta
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Source < out[j].Source
+	})
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Target < out[j].Target
+	})
+
+	// sort keys by relative value of delta
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Amount.GT(out[j].Amount)
+	})
+
+	return out
+}
+
+// MinDeltas returns the lowest value in a slice of Deltas.
+func MinDeltas(deltas ValidatorIntents) sdkmath.Int {
+	minValue := sdk.NewInt(math.MaxInt64)
+	for _, intent := range deltas {
+		if minValue.GT(intent.Weight.TruncateInt()) {
+			minValue = intent.Weight.TruncateInt()
+		}
+	}
+
+	return minValue
+}
+
+// MaxDeltas returns the greatest value in a slice of Deltas.
+func MaxDeltas(deltas ValidatorIntents) sdkmath.Int {
+	maxValue := sdk.NewInt(math.MinInt64)
+	for _, intent := range deltas {
+		if maxValue.LT(intent.Weight.TruncateInt()) {
+			maxValue = intent.Weight.TruncateInt()
+		}
+	}
+
+	return maxValue
+}

--- a/x/interchainstaking/types/redemptions.go
+++ b/x/interchainstaking/types/redemptions.go
@@ -1,0 +1,128 @@
+package types
+
+import (
+	"fmt"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func DetermineAllocationsForUndelegation(currentAllocations map[string]math.Int, currentSum math.Int, targetAllocations ValidatorIntents, availablePerValidator map[string]math.Int, amount sdk.Coins) map[string]math.Int {
+	input := amount[0].Amount
+	deltas := CalculateDeltas(currentAllocations, currentSum.Sub(input), targetAllocations)
+	sum := sdk.ZeroInt()
+	outSum := sdk.ZeroInt()
+	outWeights := make(map[string]math.Int)
+
+	// deltas: +ve is below target; -ve is above target.
+
+	// q1: can we satisfy this unbonding using _just_ above target allocations.
+	// example:
+	// we have v1: 5000, v2: 1800; v3: 1200; v4: 1000 and targets of 50%, 20%, 15% and 5% respectively.
+	// deltas == 500, 0, -150, 550
+	// an unbonding of 300 should come from v1, v4 (as they has an excess of > unbond amount) _before_ touching anything else.
+
+	for idx := range deltas {
+		if deltas[idx].Weight.IsNegative() {
+			sum = sum.Add(deltas[idx].Weight.TruncateInt().Abs())
+		}
+	}
+
+	overAllocationSplit := sdk.MinInt(sum, input)
+	if !overAllocationSplit.IsZero() {
+		for idx := range deltas {
+			if deltas[idx].Weight.IsNegative() {
+				fmt.Println("trying to remove from overallocated", deltas[idx].ValoperAddress)
+				outWeights[deltas[idx].ValoperAddress] = deltas[idx].Weight.Quo(sdk.NewDecFromInt(sum)).Mul(sdk.NewDecFromInt(overAllocationSplit)).TruncateInt().Abs()
+				if outWeights[deltas[idx].ValoperAddress].GT(availablePerValidator[deltas[idx].ValoperAddress]) {
+					outWeights[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress]
+					availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
+				} else {
+					availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(outWeights[deltas[idx].ValoperAddress])
+				}
+				fmt.Println("removed from overallocated", outWeights[deltas[idx].ValoperAddress])
+				deltas[idx].Weight = deltas[idx].Weight.Add(sdk.NewDecFromInt(outWeights[deltas[idx].ValoperAddress]))
+				outSum = outSum.Add(outWeights[deltas[idx].ValoperAddress])
+			}
+		}
+	}
+	input = input.Sub(outSum)
+	if input.IsZero() {
+		return outWeights
+	}
+
+	maxValue := MaxDeltas(deltas)
+	sum = sdk.ZeroInt()
+
+	// drop all deltas such that the maximum value is zero, and invert.
+	for idx := range deltas {
+		deltas[idx].Weight = deltas[idx].Weight.Sub(sdk.NewDecFromInt(maxValue)).Abs()
+		sum = sum.Add(deltas[idx].Weight.TruncateInt().Abs())
+
+	}
+
+	// unequalSplit is the portion of input that should be distributed in attempt to make targets == 0
+	unequalSplit := sdk.MinInt(sum, input)
+
+	if !unequalSplit.IsZero() {
+		for idx := range deltas {
+			allocation := deltas[idx].Weight.Quo(sdk.NewDecFromInt(sum)).Mul(sdk.NewDecFromInt(unequalSplit))
+			_, ok := availablePerValidator[deltas[idx].ValoperAddress]
+			if !ok {
+				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
+			}
+
+			if allocation.TruncateInt().GT(availablePerValidator[deltas[idx].ValoperAddress]) {
+				allocation = sdk.NewDecFromInt(availablePerValidator[deltas[idx].ValoperAddress])
+				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
+			} else {
+				availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(allocation.TruncateInt())
+			}
+
+			deltas[idx].Weight = deltas[idx].Weight.Sub(allocation)
+			value, ok := outWeights[deltas[idx].ValoperAddress]
+			if !ok {
+				value = sdk.ZeroInt()
+			}
+
+			outWeights[deltas[idx].ValoperAddress] = value.Add(allocation.TruncateInt())
+			outSum = outSum.Add(allocation.TruncateInt())
+			input = input.Sub(allocation.TruncateInt())
+		}
+	}
+
+	// equalSplit is the portion of input that should be distributed equally across all validators, once targets are met.
+
+	if !outSum.Equal(amount[0].Amount) {
+		each := sdk.NewDecFromInt(input).Quo(sdk.NewDec(int64(len(deltas))))
+		for idx := range deltas {
+			value, ok := outWeights[deltas[idx].ValoperAddress]
+			if !ok {
+				value = sdk.ZeroInt()
+			}
+			if each.TruncateInt().GT(availablePerValidator[deltas[idx].ValoperAddress]) {
+				each = sdk.NewDecFromInt(availablePerValidator[deltas[idx].ValoperAddress])
+				availablePerValidator[deltas[idx].ValoperAddress] = sdk.ZeroInt()
+			} else {
+				availablePerValidator[deltas[idx].ValoperAddress] = availablePerValidator[deltas[idx].ValoperAddress].Sub(each.TruncateInt())
+			}
+			outWeights[deltas[idx].ValoperAddress] = value.Add(each.TruncateInt())
+			outSum = outSum.Add(each.TruncateInt())
+			input = input.Sub(each.TruncateInt())
+		}
+	}
+
+	// dust is the portion of the input that was truncated in previous calculations; add this to the last validator in the list,
+	// which should be the biggest source. This will always be a small amount, and will count toward the delta calculations on the next run.
+	dust := amount[0].Amount.Sub(outSum)
+	for idx := len(deltas) - 1; idx >= 0; idx-- {
+		if dust.GT(availablePerValidator[deltas[idx].ValoperAddress]) {
+			continue
+		} else {
+			outWeights[deltas[idx].ValoperAddress] = outWeights[deltas[idx].ValoperAddress].Add(dust)
+			break
+		}
+	}
+
+	return outWeights
+}

--- a/x/interchainstaking/types/redemptions_test.go
+++ b/x/interchainstaking/types/redemptions_test.go
@@ -1,13 +1,14 @@
-package keeper
+package types_test
 
 import (
 	"fmt"
 	"testing"
 
-	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
 func TestDetermineAllocationsForUndelegation(t *testing.T) {
@@ -17,21 +18,21 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 	v4 := "cosmosvaloper1vx4el3dyqzucc3jhc6leaxt8gg9sar78elrce7wvyqsk9uu2d99slwapz3"
 	tests := []struct {
 		name               string
-		currentAllocations map[string]math.Int
-		unlocked           map[string]math.Int
+		currentAllocations map[string]sdkmath.Int
+		unlocked           map[string]sdkmath.Int
 		targetAllocations  types.ValidatorIntents
 		amount             sdk.Coins
-		expected           map[string]math.Int
+		expected           map[string]sdkmath.Int
 	}{
 		{
 			name: "equal delegations, equal intents; no locked",
-			currentAllocations: map[string]math.Int{
+			currentAllocations: map[string]sdkmath.Int{
 				v1: sdk.NewInt(1000),
 				v2: sdk.NewInt(1000),
 				v3: sdk.NewInt(1000),
 				v4: sdk.NewInt(1000),
 			},
-			unlocked: map[string]math.Int{
+			unlocked: map[string]sdkmath.Int{
 				v1: sdk.NewInt(1000),
 				v2: sdk.NewInt(1000),
 				v3: sdk.NewInt(1000),
@@ -44,7 +45,7 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(25, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-			expected: map[string]math.Int{
+			expected: map[string]sdkmath.Int{
 				v1: sdk.NewInt(250),
 				v2: sdk.NewInt(250),
 				v3: sdk.NewInt(250),
@@ -53,14 +54,14 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 		},
 		{
 			name: "unequal delegations, equal intents; no locked",
-			currentAllocations: map[string]math.Int{
+			currentAllocations: map[string]sdkmath.Int{
 				v1: sdk.NewInt(1000), // + 25
 				v2: sdk.NewInt(950),  // -25
 				v3: sdk.NewInt(1200), // + 225
 				v4: sdk.NewInt(750),  // -225
 				// 250; 0, -25, 0, -225; 225, 200, 225, 0; 650 (275, 225, 475, 25)
 			},
-			unlocked: map[string]math.Int{
+			unlocked: map[string]sdkmath.Int{
 				v1: sdk.NewInt(1000),
 				v2: sdk.NewInt(950),
 				v3: sdk.NewInt(1200),
@@ -73,7 +74,7 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(25, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-			expected: map[string]math.Int{
+			expected: map[string]sdkmath.Int{
 				v1: sdk.NewInt(275),
 				v2: sdk.NewInt(225),
 				v3: sdk.NewInt(475),
@@ -82,13 +83,13 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 		},
 		{
 			name: "unequal delegations, unequal intents; no locked",
-			currentAllocations: map[string]math.Int{
+			currentAllocations: map[string]sdkmath.Int{
 				v1: sdk.NewInt(5000),
 				v2: sdk.NewInt(1800),
 				v3: sdk.NewInt(1200),
 				v4: sdk.NewInt(1000),
 			},
-			unlocked: map[string]math.Int{
+			unlocked: map[string]sdkmath.Int{
 				v1: sdk.NewInt(5000),
 				v2: sdk.NewInt(1800),
 				v3: sdk.NewInt(1200),
@@ -101,7 +102,7 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(5, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(300))),
-			expected: map[string]math.Int{
+			expected: map[string]sdkmath.Int{
 				v1: sdk.NewInt(154),
 				v2: sdk.NewInt(14),
 				v3: sdk.NewInt(0),
@@ -110,17 +111,17 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 		},
 		{
 			name: "unequal delegations, unequal intents, big discrepancy in intent (should not take from underallocated); no locked",
-			currentAllocations: map[string]math.Int{
-				v1: sdk.NewInt(1234),
-				v2: sdk.NewInt(675),
-				v3: sdk.NewInt(210),
-				v4: sdk.NewInt(401),
+			currentAllocations: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(1234),
+				v2: sdkmath.NewInt(675),
+				v3: sdkmath.NewInt(210),
+				v4: sdkmath.NewInt(401),
 			},
-			unlocked: map[string]math.Int{
-				v1: sdk.NewInt(1234),
-				v2: sdk.NewInt(675),
-				v3: sdk.NewInt(210),
-				v4: sdk.NewInt(401),
+			unlocked: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(1234),
+				v2: sdkmath.NewInt(675),
+				v3: sdkmath.NewInt(210),
+				v4: sdkmath.NewInt(401),
 			},
 			targetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: v1, Weight: sdk.NewDecWithPrec(10, 2)},
@@ -129,26 +130,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(40, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
-			expected: map[string]math.Int{
-				v1: sdk.NewInt(84),
-				v2: sdk.NewInt(16),
-				v3: sdk.NewInt(0),
-				v4: sdk.NewInt(0),
+			expected: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(84),
+				v2: sdkmath.NewInt(16),
+				v3: sdkmath.NewInt(0),
+				v4: sdkmath.NewInt(0),
 			},
 		},
 		{
 			name: "equal delegations, equal intents; v1 partially locked",
-			currentAllocations: map[string]math.Int{
-				v1: sdk.NewInt(1000),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			currentAllocations: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(1000),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]math.Int{
-				v1: sdk.NewInt(500),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			unlocked: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(500),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
 			targetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: v1, Weight: sdk.NewDecWithPrec(25, 2)},
@@ -157,26 +158,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(25, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-			expected: map[string]math.Int{
-				v1: sdk.NewInt(250),
-				v2: sdk.NewInt(250),
-				v3: sdk.NewInt(250),
-				v4: sdk.NewInt(250),
+			expected: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(250),
+				v2: sdkmath.NewInt(250),
+				v3: sdkmath.NewInt(250),
+				v4: sdkmath.NewInt(250),
 			},
 		},
 		{
 			name: "equal delegations, equal intents; v1 partially locked #2",
-			currentAllocations: map[string]math.Int{
-				v1: sdk.NewInt(1000),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			currentAllocations: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(1000),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]math.Int{
-				v1: sdk.NewInt(200),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			unlocked: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(200),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
 			targetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: v1, Weight: sdk.NewDecWithPrec(25, 2)},
@@ -185,26 +186,26 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(25, 2)},
 			},
 			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-			expected: map[string]math.Int{
-				v1: sdk.NewInt(200),
-				v2: sdk.NewInt(276),
-				v3: sdk.NewInt(262),
-				v4: sdk.NewInt(262),
+			expected: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(200),
+				v2: sdkmath.NewInt(276),
+				v3: sdkmath.NewInt(262),
+				v4: sdkmath.NewInt(262),
 			},
 		},
 		{
 			name: "equal delegations, equal intents; v1 completely locked",
-			currentAllocations: map[string]math.Int{
-				v1: sdk.NewInt(1000),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			currentAllocations: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(1000),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
-			unlocked: map[string]math.Int{
-				v1: sdk.NewInt(0),
-				v2: sdk.NewInt(1000),
-				v3: sdk.NewInt(1000),
-				v4: sdk.NewInt(1000),
+			unlocked: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(0),
+				v2: sdkmath.NewInt(1000),
+				v3: sdkmath.NewInt(1000),
+				v4: sdkmath.NewInt(1000),
 			},
 			targetAllocations: types.ValidatorIntents{
 				&types.ValidatorIntent{ValoperAddress: v1, Weight: sdk.NewDecWithPrec(25, 2)},
@@ -212,17 +213,17 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 				&types.ValidatorIntent{ValoperAddress: v3, Weight: sdk.NewDecWithPrec(25, 2)},
 				&types.ValidatorIntent{ValoperAddress: v4, Weight: sdk.NewDecWithPrec(25, 2)},
 			},
-			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-			expected: map[string]math.Int{
-				v1: sdk.NewInt(0),
-				v2: sdk.NewInt(376),
-				v3: sdk.NewInt(312),
-				v4: sdk.NewInt(312),
+			amount: sdk.NewCoins(sdk.NewCoin("uatom", sdkmath.NewInt(1000))),
+			expected: map[string]sdkmath.Int{
+				v1: sdkmath.NewInt(0),
+				v2: sdkmath.NewInt(376),
+				v3: sdkmath.NewInt(312),
+				v4: sdkmath.NewInt(312),
 			},
 		},
 	}
 	for testidx, tt := range tests {
-		sum := func(in map[string]math.Int) math.Int {
+		sum := func(in map[string]sdkmath.Int) sdkmath.Int {
 			out := sdk.ZeroInt()
 			for _, i := range in {
 				out = out.Add(i)
@@ -230,7 +231,7 @@ func TestDetermineAllocationsForUndelegation(t *testing.T) {
 			return out
 		}
 		fmt.Printf("=============== case %d ===============\n", testidx)
-		allocations := DetermineAllocationsForUndelegation(tt.currentAllocations, sum(tt.currentAllocations), tt.targetAllocations, tt.unlocked, tt.amount)
+		allocations := types.DetermineAllocationsForUndelegation(tt.currentAllocations, sum(tt.currentAllocations), tt.targetAllocations, tt.unlocked, tt.amount)
 		for valoper := range allocations {
 			require.Equal(t, tt.expected[valoper].Int64(), allocations[valoper].Int64(), fmt.Sprintf("%s (%d) / %s", tt.name, testidx, valoper))
 		}

--- a/x/participationrewards/keeper/callbacks.go
+++ b/x/participationrewards/keeper/callbacks.go
@@ -79,15 +79,15 @@ func ValidatorSelectionRewardsCallback(k Keeper, ctx sdk.Context, response []byt
 	)
 
 	// snapshot obtained and used here
-	userAllocations := k.calcUserValidatorSelectionAllocations(ctx, zone, *zs)
+	userAllocations := k.calcUserValidatorSelectionAllocations(ctx, &zone, *zs)
 
 	if err := k.distributeToUsers(ctx, userAllocations); err != nil {
 		return err
 	}
 
 	// create snapshot of current intents for next epoch boundary
-	for _, di := range k.icsKeeper.AllIntents(ctx, zone, false) {
-		k.icsKeeper.SetIntent(ctx, zone, di, true)
+	for _, di := range k.icsKeeper.AllIntents(ctx, &zone, false) {
+		k.icsKeeper.SetIntent(ctx, &zone, di, true)
 	}
 
 	// set zone ValidatorSelectionAllocation to zero

--- a/x/participationrewards/keeper/distribution.go
+++ b/x/participationrewards/keeper/distribution.go
@@ -56,9 +56,9 @@ func (k Keeper) calcTokenValues(ctx sdk.Context) (tokenValues, error) {
 
 	// get base zone (Cosmos)
 	var cosmosZone *icstypes.Zone
-	k.icsKeeper.IterateZones(ctx, func(_ int64, zone icstypes.Zone) (stop bool) {
+	k.icsKeeper.IterateZones(ctx, func(_ int64, zone *icstypes.Zone) (stop bool) {
 		if zone.AccountPrefix == "cosmos" {
-			cosmosZone = &zone
+			cosmosZone = zone
 			return true
 		}
 		return false

--- a/x/participationrewards/keeper/hooks.go
+++ b/x/participationrewards/keeper/hooks.go
@@ -77,8 +77,8 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			// ValidatorSelectionRewardsCallback;
 			for _, zone := range k.icsKeeper.AllZones(ctx) {
 				zone := zone
-				for _, di := range k.icsKeeper.AllIntents(ctx, zone, false) {
-					k.icsKeeper.SetIntent(ctx, zone, di, true)
+				for _, di := range k.icsKeeper.AllIntents(ctx, &zone, false) {
+					k.icsKeeper.SetIntent(ctx, &zone, di, true)
 				}
 			}
 

--- a/x/participationrewards/keeper/keeper_test.go
+++ b/x/participationrewards/keeper/keeper_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ingenuity-build/quicksilver/utils"
 	cmtypes "github.com/ingenuity-build/quicksilver/x/claimsmanager/types"
 	ics "github.com/ingenuity-build/quicksilver/x/interchainstaking"
-	icskeeper "github.com/ingenuity-build/quicksilver/x/interchainstaking/keeper"
 	icstypes "github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 	"github.com/ingenuity-build/quicksilver/x/participationrewards/types"
 )
@@ -175,13 +174,13 @@ func (suite *KeeperTestSuite) setupTestZones() {
 		// refetch the zone for each validator, else we end up with an empty valset each time!
 		zone, found := qApp.InterchainstakingKeeper.GetZone(suite.chainA.GetContext(), suite.chainB.ChainID)
 		suite.Require().True(found)
-		suite.Require().NoError(icskeeper.SetValidatorForZone(&qApp.InterchainstakingKeeper, suite.chainA.GetContext(), zone, app.DefaultConfig().Codec.MustMarshal(&val)))
+		suite.Require().NoError(qApp.InterchainstakingKeeper.SetValidatorForZone(suite.chainA.GetContext(), &zone, app.DefaultConfig().Codec.MustMarshal(&val)))
 	}
 
 	for _, val := range suite.GetQuicksilverApp(suite.chainA).StakingKeeper.GetBondedValidatorsByPower(suite.chainA.GetContext()) {
 		zone, found := qApp.InterchainstakingKeeper.GetZone(suite.chainA.GetContext(), suite.chainA.ChainID)
 		suite.Require().True(found)
-		suite.Require().NoError(icskeeper.SetValidatorForZone(&qApp.InterchainstakingKeeper, suite.chainA.GetContext(), zone, app.DefaultConfig().Codec.MustMarshal(&val)))
+		suite.Require().NoError(qApp.InterchainstakingKeeper.SetValidatorForZone(suite.chainA.GetContext(), &zone, app.DefaultConfig().Codec.MustMarshal(&val)))
 	}
 
 	// self zone
@@ -504,7 +503,7 @@ func (suite *KeeperTestSuite) addIntent(address string, zone icstypes.Zone, inte
 		Delegator: address,
 		Intents:   intents,
 	}
-	suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper.SetIntent(suite.chainA.GetContext(), zone, intent, false)
+	suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper.SetIntent(suite.chainA.GetContext(), &zone, intent, false)
 }
 
 func (suite *KeeperTestSuite) setupTestClaims() {

--- a/x/participationrewards/keeper/rewards_validatorSelection.go
+++ b/x/participationrewards/keeper/rewards_validatorSelection.go
@@ -254,7 +254,7 @@ func (k Keeper) calcOverallScores(
 // proportionally allocates rewards based on the individual zone allocation.
 func (k Keeper) calcUserValidatorSelectionAllocations(
 	ctx sdk.Context,
-	zone icstypes.Zone,
+	zone *icstypes.Zone,
 	zs zoneScore,
 ) []userAllocation {
 	k.Logger(ctx).Info("calcUserValidatorSelectionAllocations", "zone", zone.ChainId, "scores", zs, "allocation", zone.ValidatorSelectionAllocation)


### PR DESCRIPTION
## 1. Summary

`interchainstaking` is our most complicated module and package in the codebase.  This PR attempts to refactor and modularize the `keeper` package.  Maintenance like this can help us with adding features, instrumentation and testing moving forward.

## 2.Type of change

- [X] refactor

## 3. Implementation details

- move non-keeper methods to the `types` package
- modularize function calls more
- unify keeper function signatures so that they are all pointer receivers
- pass `Zone` struct as a pointer to our functions

## 4. How to test/use

Verify functionality is not modified by this PR.

## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 6. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 7. Future Work (optional)

<!-- Describe follow up work, if any. -->