### PR TITLE
fix: modify app.go init

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,7 +46,7 @@ import (
 	interchainstakingtypes "github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func Init() {
+func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## 1. Summary

`Init()` in `app.go` was not being called like a normal `go` `init()` function because it was capitalized.