### PR TITLE
Release/v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Released
 
+### v1.2.6
+- fix release height
+
 ### v1.2.5
 - Backport `GovRepenChannel` tx and `GovCloseChannel` proposal
 - Add Logic to handle pending delegations on `regen-1` post upgrade once channel are open.

--- a/x/interchainstaking/keeper/abci.go
+++ b/x/interchainstaking/keeper/abci.go
@@ -17,7 +17,7 @@ type zoneItrFn func(index int64, zoneInfo types.Zone) (stop bool)
 func (k Keeper) BeginBlocker(ctx sdk.Context) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 	// post upgrade-v1.2.5 processing
-	if ctx.BlockHeight() == 14540740 {
+	if ctx.BlockHeight() == 1116500 && ctx.ChainID() == "quicksilver-2" {
 		zone, found := k.GetZone(ctx, "regen-1")
 		if found {
 			k.IterateReceipts(ctx, func(_ int64, receiptInfo types.Receipt) (stop bool) {


### PR DESCRIPTION
## 1. Summary
Fixes bad release height in v1.2.5

## 2.Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Update scheduled 'upgrade handler' to run 1116500 - 90 minutes after target upgrade height.