### PR TITLE
chore: add staticmajor analysis tool

### DIFF
--- a/.github/workflows/staticmajor.yml
+++ b/.github/workflows/staticmajor.yml
@@ -1,0 +1,17 @@
+name: Staticmajor Analysis
+on: [push,workflow_dispatch,pull_request]
+jobs:
+  run_staticmajor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Staticmajor action
+        id: staticmajor
+        uses: orijtech/staticmajor-action@main
+        with:
+          resleak: true
+          httperroryzer: true
+          structslop: true
+          fuzzy: true
+          generated: false


### PR DESCRIPTION
## 1. Summary

Add `staticmajor` tool as a gh workflow.  Configured to run all checks and ignore proto generated files.
