### PR TITLE
Fix: frontport prefix stripping; validate basic for MsgGovReopenChannel

### DIFF
--- a/x/interchainstaking/keeper/msg_server.go
+++ b/x/interchainstaking/keeper/msg_server.go
@@ -154,17 +154,11 @@ func (k msgServer) SignalIntent(goCtx context.Context, msg *types.MsgSignalInten
 func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReopenChannel) (*types.MsgGovReopenChannelResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// checking msg authority is the gov module address
-	// if k.Keeper.GetGovAuthority(ctx) != msg.Authority {
-	// 	return &types.MsgGovReopenChannelResponse{},
-	// 		govtypes.ErrInvalidSigner.Wrapf(
-	// 			"invalid authority: expected %s, got %s",
-	// 			k.Keeper.GetGovAuthority(ctx), msg.Authority,
-	// 		)
-	// }
+	// remove leading prefix icacontroller- if passed in msg
+	portID := strings.ReplaceAll(msg.PortId, "icacontroller-", "")
 
 	// validate the zone exists, and the format is valid (e.g. quickgaia-1.delegate)
-	parts := strings.Split(msg.PortId, ".")
+	parts := strings.Split(portID, ".")
 	if len(parts) != 2 {
 		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format")
 	}

--- a/x/interchainstaking/keeper/msg_server.go
+++ b/x/interchainstaking/keeper/msg_server.go
@@ -171,7 +171,7 @@ func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReop
 		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format; zone not found")
 	}
 
-	if err := k.Keeper.registerInterchainAccount(ctx, msg.ConnectionId, msg.PortId); err != nil {
+	if err := k.Keeper.registerInterchainAccount(ctx, msg.ConnectionId, portID); err != nil {
 		return &types.MsgGovReopenChannelResponse{}, err
 	}
 
@@ -182,7 +182,7 @@ func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReop
 		),
 		sdk.NewEvent(
 			types.EventTypeReopenICA,
-			sdk.NewAttribute(types.AttributeKeyPortID, msg.PortId),
+			sdk.NewAttribute(types.AttributeKeyPortID, portID),
 			sdk.NewAttribute(types.AttributeKeyConnectionID, msg.ConnectionId),
 		),
 	})

--- a/x/interchainstaking/keeper/msg_server.go
+++ b/x/interchainstaking/keeper/msg_server.go
@@ -163,12 +163,12 @@ func (k msgServer) GovReopenChannel(goCtx context.Context, msg *types.MsgGovReop
 		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format")
 	}
 
-	if _, found := k.GetZone(ctx, parts[0]); !found {
-		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format; zone not found")
-	}
-
 	if parts[1] != "delegate" && parts[1] != "deposit" && parts[1] != "performance" && parts[1] != "withdrawal" {
 		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format; unexpected account")
+	}
+
+	if _, found := k.GetZone(ctx, parts[0]); !found {
+		return &types.MsgGovReopenChannelResponse{}, errors.New("invalid port format; zone not found")
 	}
 
 	if err := k.Keeper.registerInterchainAccount(ctx, msg.ConnectionId, msg.PortId); err != nil {

--- a/x/interchainstaking/types/msgs.go
+++ b/x/interchainstaking/types/msgs.go
@@ -230,4 +230,25 @@ func (msg MsgGovReopenChannel) GetSigners() []sdk.AccAddress {
 }
 
 // check channel id is correct format. validate port name?
-func (msg MsgGovReopenChannel) ValidateBasic() error { return nil }
+func (msg MsgGovReopenChannel) ValidateBasic() error {
+
+	// validate the zone exists, and the format is valid (e.g. quickgaia-1.delegate)
+	parts := strings.Split(msg.PortId, ".")
+	if len(parts) != 2 {
+		return errors.New("invalid port format")
+	}
+
+	if parts[1] != "delegate" && parts[1] != "deposit" && parts[1] != "performance" && parts[1] != "withdrawal" {
+		return errors.New("invalid port format; unexpected account")
+	}
+
+	if len(msg.ConnectionId) < 12 {
+		return errors.New("invalid connection string; too short")
+	}
+
+	if msg.ConnectionId[0:11] != "connection-" {
+		return errors.New("invalid connection string; incorrect prefix")
+	}
+
+	return nil
+}

--- a/x/interchainstaking/types/msgs.go
+++ b/x/interchainstaking/types/msgs.go
@@ -231,7 +231,6 @@ func (msg MsgGovReopenChannel) GetSigners() []sdk.AccAddress {
 
 // check channel id is correct format. validate port name?
 func (msg MsgGovReopenChannel) ValidateBasic() error {
-
 	// validate the zone exists, and the format is valid (e.g. quickgaia-1.delegate)
 	parts := strings.Split(msg.PortId, ".")
 	if len(parts) != 2 {

--- a/x/interchainstaking/types/msgs_test.go
+++ b/x/interchainstaking/types/msgs_test.go
@@ -241,8 +241,8 @@ func TestMsgRequestRedemption_ValidateBasic(t *testing.T) {
 
 func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 	type fields struct {
-		PortId       string
-		ConnectionId string
+		PortID       string
+		ConnectionID string
 		FromAddress  string
 	}
 	tests := []struct {
@@ -260,7 +260,7 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 		{
 			"invalid port",
 			fields{
-				PortId: "cat",
+				PortID: "cat",
 			},
 			true,
 			"invalid port format",
@@ -268,7 +268,7 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 		{
 			"invalid account",
 			fields{
-				PortId: "icacontroller-osmosis-4.bad",
+				PortID: "icacontroller-osmosis-4.bad",
 			},
 			true,
 			"invalid port format; unexpected account",
@@ -276,8 +276,8 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 		{
 			"invalid connection; too short",
 			fields{
-				PortId:       "icacontroller-osmosis-4.withdrawal",
-				ConnectionId: "bad-1",
+				PortID:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionID: "bad-1",
 			},
 			true,
 			"invalid connection string; too short",
@@ -285,8 +285,8 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 		{
 			"invalid connection; too short",
 			fields{
-				PortId:       "icacontroller-osmosis-4.withdrawal",
-				ConnectionId: "longenoughbutstillbad-1",
+				PortID:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionID: "longenoughbutstillbad-1",
 			},
 			true,
 			"invalid connection string; incorrect prefix",
@@ -294,8 +294,8 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 		{
 			"valid",
 			fields{
-				PortId:       "icacontroller-osmosis-4.withdrawal",
-				ConnectionId: "connection-1",
+				PortID:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionID: "connection-1",
 			},
 			false,
 			"",
@@ -304,8 +304,8 @@ func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			msg := types.MsgGovReopenChannel{
-				PortId:       tt.fields.PortId,
-				ConnectionId: tt.fields.ConnectionId,
+				PortId:       tt.fields.PortID,
+				ConnectionId: tt.fields.ConnectionID,
 				Authority:    tt.fields.FromAddress,
 			}
 			err := msg.ValidateBasic()

--- a/x/interchainstaking/types/msgs_test.go
+++ b/x/interchainstaking/types/msgs_test.go
@@ -238,3 +238,84 @@ func TestMsgRequestRedemption_ValidateBasic(t *testing.T) {
 		})
 	}
 }
+
+func TestMsgReopenIntent_ValidateBasic(t *testing.T) {
+	type fields struct {
+		PortId       string
+		ConnectionId string
+		FromAddress  string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		wantErr  bool
+		errorMsg string
+	}{
+		{
+			"blank",
+			fields{},
+			true,
+			"invalid port format",
+		},
+		{
+			"invalid port",
+			fields{
+				PortId: "cat",
+			},
+			true,
+			"invalid port format",
+		},
+		{
+			"invalid account",
+			fields{
+				PortId: "icacontroller-osmosis-4.bad",
+			},
+			true,
+			"invalid port format; unexpected account",
+		},
+		{
+			"invalid connection; too short",
+			fields{
+				PortId:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionId: "bad-1",
+			},
+			true,
+			"invalid connection string; too short",
+		},
+		{
+			"invalid connection; too short",
+			fields{
+				PortId:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionId: "longenoughbutstillbad-1",
+			},
+			true,
+			"invalid connection string; incorrect prefix",
+		},
+		{
+			"valid",
+			fields{
+				PortId:       "icacontroller-osmosis-4.withdrawal",
+				ConnectionId: "connection-1",
+			},
+			false,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := types.MsgGovReopenChannel{
+				PortId:       tt.fields.PortId,
+				ConnectionId: tt.fields.ConnectionId,
+				Authority:    tt.fields.FromAddress,
+			}
+			err := msg.ValidateBasic()
+			if tt.wantErr {
+				t.Logf("Error:\n%v\n", err)
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errorMsg)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## 1. Summary
Fixes QCK-287

Add validate basic for MsgGovReopenChannel + tests
Migrate stateless checks to validate basic
Frontport ICAController prefix change from v1.2.9

## 2.Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

- Migrate stateless checks to validate basic and remove from msg_server
- Add tests for validate basic
- Front port v1.2.9 change for stripping icacontroller- prefix from a port.
