### PR TITLE
fix: codecov uploads

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -4,7 +4,13 @@ name: build and test
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - "develop"
+      - "main"
 
 # This workflow makes x86_64 for windows, and linux.
 


### PR DESCRIPTION
## 1. Summary
Fixes QCK-328

Upload reports on pushes to `main` and `develop` so we can compare against base coverages.