### PR TITLE
improvement: route non staking denom rewards to qasset holders [QCK-417]

### DIFF
--- a/x/interchainstaking/keeper/zones.go
+++ b/x/interchainstaking/keeper/zones.go
@@ -164,6 +164,14 @@ func (k *Keeper) GetZoneForDepositAccount(ctx sdk.Context, address string) *type
 	return nil
 }
 
+func (k *Keeper) GetZoneForWithdrawalAccount(ctx sdk.Context, address string) *types.Zone {
+	z := k.GetZoneForAccount(ctx, address)
+	if z != nil && z.WithdrawalAddress != nil && address == z.WithdrawalAddress.Address {
+		return z
+	}
+	return nil
+}
+
 func (k *Keeper) EnsureWithdrawalAddresses(ctx sdk.Context, zone *types.Zone) error {
 	if zone.WithdrawalAddress == nil {
 		k.Logger(ctx).Info("Withdrawal address not set")


### PR DESCRIPTION
## 1. Summary
Fixes QCK-417

Route non- staking denom rewards into the quick bech32ification of the withdrawal account, for distribution by the participation rewards module.

## 2.Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## 3. Implementation details

As discussed in #425, non staking denom rewards, such as those emitted by RS consumer chains, need to be routed to a per-zone pool for dispersal by participation rewards, instead of being sent directly to the `feeCollectorPool`.

If the received denom is _not_ the staking token associated with the zone (identified by the withdrawal address), then we take a fee equal to `k.GetCommissionRate()` and send _this_ to the `feeCollectorPool` and the remainder is sent to the `quick`-prefixed bech32 address for zone's withdrawal account. This avoids us generating and storing another yet another address field. The withdrawal address on the host zone is constant for the life of the zone, so using it's 'quick' prefixed counterpart is safe.

## 4. How to test/use

Send non staking denom tokens to the withdrawal account for a host zone. 3.5% of these tokens should end up distributed to QCK token holders, and 96.5% should end up in the quick prefixed address corresponding to the zone's withdrawal address.

## 5. Checklist

## 6. Limitations (optional)

This change does not handle the distribution of these tokens to the qasset holders.

## 7. Future Work (optional)

Add additional logic into participation rewards to distribute these tokens to qasset holders.