### PR TITLE
fix: QCK-425 update delegations on redelegation

### DIFF
--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -22,6 +22,7 @@ const (
 	V010402rc3UpgradeName = "v1.4.2-rc3"
 	V010402rc4UpgradeName = "v1.4.2-rc4"
 	V010402rc5UpgradeName = "v1.4.2-rc5"
+	V010402rc6UpgradeName = "v1.4.2-rc6"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -224,7 +224,6 @@ func V010402rc6UpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		if isTestnet(ctx) || isTest(ctx) {
-
 			// for each zone, trigger an icq request to update all delegations.
 			appKeepers.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *types.Zone) (stop bool) {
 				vals := appKeepers.InterchainstakingKeeper.GetValidators(ctx, zone.ChainId)

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -6,6 +6,8 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/ingenuity-build/quicksilver/app/keepers"
@@ -21,6 +23,7 @@ func Upgrades() []Upgrade {
 		{UpgradeName: V010402rc3UpgradeName, CreateUpgradeHandler: V010402rc3UpgradeHandler},
 		{UpgradeName: V010402rc4UpgradeName, CreateUpgradeHandler: V010402rc4UpgradeHandler},
 		{UpgradeName: V010402rc5UpgradeName, CreateUpgradeHandler: V010402rc5UpgradeHandler},
+		{UpgradeName: V010402rc6UpgradeName, CreateUpgradeHandler: V010402rc6UpgradeHandler},
 	}
 }
 
@@ -208,6 +211,39 @@ func V010402rc5UpgradeHandler(
 				appKeepers.InterchainstakingKeeper.SetReceipt(ctx, rcpt)
 			}
 
+		}
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
+func V010402rc6UpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	appKeepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		if isTestnet(ctx) || isTest(ctx) {
+
+			// for each zone, trigger an icq request to update all delegations.
+			appKeepers.InterchainstakingKeeper.IterateZones(ctx, func(index int64, zone *types.Zone) (stop bool) {
+				vals := appKeepers.InterchainstakingKeeper.GetValidators(ctx, zone.ChainId)
+				delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(vals))}}
+				bz := appKeepers.InterchainstakingKeeper.GetCodec().MustMarshal(&delegationQuery)
+
+				appKeepers.InterchainstakingKeeper.ICQKeeper.MakeRequest(
+					ctx,
+					zone.ConnectionId,
+					zone.ChainId,
+					"cosmos.staking.v1beta1.Query/DelegatorDelegations",
+					bz,
+					sdk.NewInt(-1),
+					types.ModuleName,
+					"delegations",
+					0,
+				)
+				return false
+			})
 		}
 
 		return mm.RunMigrations(ctx, configurator, fromVM)

--- a/x/interchainstaking/keeper/redemptions.go
+++ b/x/interchainstaking/keeper/redemptions.go
@@ -113,7 +113,7 @@ func (k *Keeper) GetUnlockedTokensForZone(ctx sdk.Context, zone *types.Zone) (ma
 		if found {
 			availablePerValidator[redelegation.Destination] = thisAvailable.Sub(sdk.NewInt(redelegation.Amount))
 			if availablePerValidator[redelegation.Destination].LT(sdk.ZeroInt()) {
-				panic("negative available amount; unable to continue")
+				panic(fmt.Sprintf("negative available amount [chain: %s, validator: %s, amount: %s]; unable to continue", zone.ChainId, redelegation.Destination, availablePerValidator[redelegation.Destination].String()))
 			}
 			total = total.Sub(sdk.NewInt(redelegation.Amount))
 		}

--- a/x/interchainstaking/keeper/redemptions.go
+++ b/x/interchainstaking/keeper/redemptions.go
@@ -232,15 +232,25 @@ WITHDRAWAL:
 	var msgs []sdk.Msg
 	for _, valoper := range utils.Keys(valOutCoinsMap) {
 		if !valOutCoinsMap[valoper].Amount.IsZero() {
-			sort.Strings(txHashes[valoper])
-			k.SetUnbondingRecord(ctx, types.UnbondingRecord{ChainId: zone.ChainId, EpochNumber: epoch, Validator: valoper, RelatedTxhash: txHashes[valoper]})
 			msgs = append(msgs, &stakingtypes.MsgUndelegate{DelegatorAddress: zone.DelegationAddress.Address, ValidatorAddress: valoper, Amount: valOutCoinsMap[valoper]})
 		}
 	}
 
 	k.Logger(ctx).Info("unbonding messages to send", "msg", msgs)
 
-	return k.SubmitTx(ctx, msgs, zone.DelegationAddress, fmt.Sprintf("withdrawal/%d", epoch), zone.MessagesPerTx)
+	err = k.SubmitTx(ctx, msgs, zone.DelegationAddress, fmt.Sprintf("withdrawal/%d", epoch), zone.MessagesPerTx)
+	if err != nil {
+		return err
+	}
+
+	for _, valoper := range utils.Keys(valOutCoinsMap) {
+		if !valOutCoinsMap[valoper].Amount.IsZero() {
+			sort.Strings(txHashes[valoper])
+			k.SetUnbondingRecord(ctx, types.UnbondingRecord{ChainId: zone.ChainId, EpochNumber: epoch, Validator: valoper, RelatedTxhash: txHashes[valoper]})
+		}
+	}
+
+	return nil
 }
 
 func (k *Keeper) GCCompletedUnbondings(ctx sdk.Context, zone *types.Zone) error {


### PR DESCRIPTION
## 1. Summary
Fixes # QCK-425

Avoid panic at epoch by ensuring redelegations cause update of underlying delegation records for both source and dst validators.

## 2.Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

When MsgBeginRedelegate acknowledge is received, we now update both the source and destination validator delegation records based upon the amount that was redelegated. Additionally, we trigger a KV store lookup against both delegations to ensure they are accurate against the host chain. 

The reason we do both is to avoid potential race conditions, where a redelegation might be acknowledged, and we use the delegation message immediately after before the ICQ request has an opportunity to be updated.

## 4. How to test/use

Trigger a redelegation at an epoch boundary (by changing intent, for example), and check the two delegation records involved reflect the redelegation change.
