### PR TITLE
fix: channel capability owned by ics; call must come from ics keeper

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -155,12 +155,8 @@ func v010209UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 
 func v0102010UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		_, capability, err := app.InterchainstakingKeeper.IBCKeeper.ChannelKeeper.LookupModuleByChannel(ctx, "icacontroller-stargaze-1.delegate", "channel-50")
-		if err != nil {
-			panic(err)
-		}
 
-		if err := app.InterchainstakingKeeper.IBCKeeper.ChannelKeeper.ChanCloseInit(ctx, "icacontroller-stargaze-1.delegate", "channel-50", capability); err != nil {
+		if err := app.InterchainstakingKeeper.ChanCloseInit(ctx, "icacontroller-stargaze-1.delegate", "channel-50"); err != nil {
 			panic(err)
 		}
 

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -635,3 +635,12 @@ func DetermineAllocationsForRebalancing(currentAllocations map[string]math.Int, 
 
 	return out
 }
+
+func (k *Keeper) ChanCloseInit(ctx sdk.Context, port, channel string) error {
+	_, capability, err := k.IBCKeeper.ChannelKeeper.LookupModuleByChannel(ctx, port, channel)
+	if err != nil {
+		return err
+	}
+
+	return k.IBCKeeper.ChannelKeeper.ChanCloseInit(ctx, port, channel, capability)
+}


### PR DESCRIPTION
Update v1.2.10 upgradehandler to ensure call to close channel originates in ics keeper.