### PR TITLE
fix: upgradehandler v1.2.10

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -7,8 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-
-	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 	minttypes "github.com/ingenuity-build/quicksilver/x/mint/types"
 )
 
@@ -155,26 +153,10 @@ func v010209UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 
 func v0102010UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		_, capability, err := app.InterchainstakingKeeper.IBCKeeper.ChannelKeeper.LookupModuleByChannel(ctx, "icacontroller-stargaze-1.delegate", "channel-50")
+		err := app.InterchainstakingKeeper.CloseICAChannel(ctx, "cacontroller-stargaze-1.delegate", "channel-50")
 		if err != nil {
 			panic(err)
 		}
-
-		if err := app.InterchainstakingKeeper.IBCKeeper.ChannelKeeper.ChanCloseInit(ctx, "icacontroller-stargaze-1.delegate", "channel-50", capability); err != nil {
-			panic(err)
-		}
-
-		ctx.EventManager().EmitEvents(sdk.Events{
-			sdk.NewEvent(
-				sdk.EventTypeMessage,
-				sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			),
-			sdk.NewEvent(
-				types.EventTypeCloseICA,
-				sdk.NewAttribute(types.AttributeKeyPortID, "icacontroller-stargaze-1.delegate"),
-				sdk.NewAttribute(types.AttributeKeyChannelID, "channel-50"),
-			),
-		})
 
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -29,7 +29,7 @@ func setUpgradeHandlers(app *Quicksilver) {
 	app.UpgradeKeeper.SetUpgradeHandler(v010204UpgradeName, v010204UpgradeHandler(app))
 	app.UpgradeKeeper.SetUpgradeHandler(v010207UpgradeName, v010207UpgradeHandler(app))
 	app.UpgradeKeeper.SetUpgradeHandler(v010209UpgradeName, v010209UpgradeHandler(app))
-	app.UpgradeKeeper.SetUpgradeHandler(v0102010UpgradeName, v0102010UpgradeHandler(app))
+	app.UpgradeKeeper.SetUpgradeHandler(v0102010UpgradeName, noOpUpgradeHandler(app))
 
 	// When a planned update height is reached, the old binary will panic
 	// writing on disk the height and name of the update that triggered it
@@ -146,17 +146,6 @@ func v010209UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
 		// block gas is 2m
 		zone.MessagesPerTx = 2
 		app.InterchainstakingKeeper.SetZone(ctx, &zone)
-
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	}
-}
-
-func v0102010UpgradeHandler(app *Quicksilver) upgradetypes.UpgradeHandler {
-	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		err := app.InterchainstakingKeeper.CloseICAChannel(ctx, "cacontroller-stargaze-1.delegate", "channel-50")
-		if err != nil {
-			panic(err)
-		}
 
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	}

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -515,31 +515,6 @@ func (k *Keeper) Rebalance(ctx sdk.Context, zone types.Zone, epochNumber int64) 
 	return k.SubmitTx(ctx, msgs, zone.DelegationAddress, fmt.Sprintf("rebalance/%d", epochNumber), zone.MessagesPerTx)
 }
 
-func (k *Keeper) CloseICAChannel(ctx sdk.Context, portID, channelID string) error {
-	_, capability, err := k.IBCKeeper.ChannelKeeper.LookupModuleByChannel(ctx, portID, channelID)
-	if err != nil {
-		return err
-	}
-
-	if err := k.IBCKeeper.ChannelKeeper.ChanCloseInit(ctx, portID, channelID, capability); err != nil {
-		return err
-	}
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-		),
-		sdk.NewEvent(
-			types.EventTypeCloseICA,
-			sdk.NewAttribute(types.AttributeKeyPortID, portID),
-			sdk.NewAttribute(types.AttributeKeyChannelID, channelID),
-		),
-	})
-
-	return nil
-}
-
 type RebalanceTarget struct {
 	Amount math.Int
 	Source string


### PR DESCRIPTION
- Update v1.2.10 upgradehandler to ensure call to close channel originates in ics keeper.