### PR TITLE
Use docker/build-push-action for IC-Test

### DIFF
--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -41,18 +41,17 @@ jobs:
         with:
           go-version: '1.20.4'
 
-      - name: Setup Golang caches
-        uses: actions/cache@v3
+      - 
+        name: Build and push 
+        id: build_push_image
+        uses: docker/build-push-action@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
-
-      - name: build and push container
-        run: make ictest-build-push
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quicksilverzone/quicksilver-e2e:latest
 
   test-quicksilver-basic:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 
 rocksdb
 data
+heighliner
 
 # python script
 autotest.py


### PR DESCRIPTION

## 1. Summary
- Go-cache is not needed when build and push image
- Use docker/build-push-action (easy to debug)
## 2.Type of change
- [ ] New feature (non-breaking change which adds functionality)
