### PR TITLE
fix: replace sdk.MustAddressFromBech32 with addressutils.AddressFromBech32 [QCK-502]

### DIFF
--- a/x/participationrewards/keeper/rewards_holdings.go
+++ b/x/participationrewards/keeper/rewards_holdings.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ingenuity-build/quicksilver/utils"
+	"github.com/ingenuity-build/quicksilver/utils/addressutils"
 	airdroptypes "github.com/ingenuity-build/quicksilver/x/airdrop/types"
 	cmtypes "github.com/ingenuity-build/quicksilver/x/claimsmanager/types"
 	icstypes "github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
@@ -94,7 +95,7 @@ func (k Keeper) CalcUserHoldingsAllocations(ctx sdk.Context, zone *icstypes.Zone
 	tokensPerAsset := sdk.NewDecFromInt(zoneAllocation).Quo(sdk.NewDecFromInt(supply.Amount))
 
 	// determine ics rewards to be distributed per token.
-	icsRewardsAddr := sdk.MustAccAddressFromBech32(zone.WithdrawalAddress.Address)
+	icsRewardsAddr, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
 	icsRewardsBalance := k.bankKeeper.GetAllBalances(ctx, icsRewardsAddr)
 	icsRewardsPerAsset := make(map[string]sdk.Dec, len(icsRewardsBalance))
 	for _, rewardsAsset := range icsRewardsBalance {

--- a/x/participationrewards/keeper/rewards_holdings.go
+++ b/x/participationrewards/keeper/rewards_holdings.go
@@ -52,6 +52,8 @@ func (k Keeper) CalcUserHoldingsAllocations(ctx sdk.Context, zone *icstypes.Zone
 
 	userAllocations := make([]types.UserAllocation, 0)
 	icsRewardsAllocations := make([]types.UserAllocation, 0)
+	icsRewardsBalance := sdk.NewCoins()
+	icsRewardsPerAsset := make(map[string]sdk.Dec, 0)
 
 	supply := k.bankKeeper.GetSupply(ctx, zone.LocalDenom)
 
@@ -94,16 +96,21 @@ func (k Keeper) CalcUserHoldingsAllocations(ctx sdk.Context, zone *icstypes.Zone
 	zoneAllocation := math.NewIntFromUint64(zone.HoldingsAllocation)
 	tokensPerAsset := sdk.NewDecFromInt(zoneAllocation).Quo(sdk.NewDecFromInt(supply.Amount))
 
-	// determine ics rewards to be distributed per token.
-	icsRewardsAddr, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
-	icsRewardsBalance := k.bankKeeper.GetAllBalances(ctx, icsRewardsAddr)
-	icsRewardsPerAsset := make(map[string]sdk.Dec, len(icsRewardsBalance))
-	for _, rewardsAsset := range icsRewardsBalance {
-		icsRewardsPerAsset[rewardsAsset.Denom] = sdk.NewDecFromInt(rewardsAsset.Amount).Quo(sdk.NewDecFromInt(supply.Amount))
-	}
+	if zone.WithdrawalAddress != nil {
+		// determine ics rewards to be distributed per token.
+		icsRewardsAddr, err := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, zone.AccountPrefix)
+		if err != nil {
+			panic("unable to unmarshal withdrawal address")
+		}
+		icsRewardsBalance = k.bankKeeper.GetAllBalances(ctx, icsRewardsAddr)
+		icsRewardsPerAsset = make(map[string]sdk.Dec, len(icsRewardsBalance))
+		for _, rewardsAsset := range icsRewardsBalance {
+			icsRewardsPerAsset[rewardsAsset.Denom] = sdk.NewDecFromInt(rewardsAsset.Amount).Quo(sdk.NewDecFromInt(supply.Amount))
+		}
 
+		k.Logger(ctx).Info("ics rewards per asset", "zone", zone.ChainId, "icsrpa", icsRewardsPerAsset)
+	}
 	k.Logger(ctx).Info("tokens per asset", "zone", zone.ChainId, "tpa", tokensPerAsset)
-	k.Logger(ctx).Info("ics rewards per asset", "zone", zone.ChainId, "icsrpa", icsRewardsPerAsset)
 
 	for _, address := range utils.Keys(userAmountsMap) {
 		amount := userAmountsMap[address]

--- a/x/participationrewards/keeper/rewards_holdings_test.go
+++ b/x/participationrewards/keeper/rewards_holdings_test.go
@@ -136,7 +136,7 @@ func (suite *KeeperTestSuite) TestCalcUserHoldingsAllocations() {
 			func(ctx sdk.Context, appA *app.Quicksilver) {
 				zone, _ := appA.InterchainstakingKeeper.GetZone(ctx, suite.chainB.ChainID)
 				zone.HoldingsAllocation = 5000
-				icsAddress := sdk.MustAccAddressFromBech32(zone.WithdrawalAddress.Address)
+				icsAddress, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin(zone.LocalDenom, sdk.NewIntFromUint64(1500)))))
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
 				suite.Require().NoError(appA.BankKeeper.SendCoinsFromModuleToAccount(ctx, "mint", icsAddress, sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
@@ -173,7 +173,7 @@ func (suite *KeeperTestSuite) TestCalcUserHoldingsAllocations() {
 			func(ctx sdk.Context, appA *app.Quicksilver) {
 				zone, _ := appA.InterchainstakingKeeper.GetZone(ctx, suite.chainB.ChainID)
 				zone.HoldingsAllocation = 5000
-				icsAddress := sdk.MustAccAddressFromBech32(zone.WithdrawalAddress.Address)
+				icsAddress, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin(zone.LocalDenom, sdk.NewIntFromUint64(1500)))))
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
 				suite.Require().NoError(appA.BankKeeper.SendCoinsFromModuleToAccount(ctx, "mint", icsAddress, sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
@@ -233,7 +233,7 @@ func (suite *KeeperTestSuite) TestCalcUserHoldingsAllocations() {
 				zone, _ := appA.InterchainstakingKeeper.GetZone(ctx, suite.chainB.ChainID)
 				zone.HoldingsAllocation = 5000
 
-				icsAddress := sdk.MustAccAddressFromBech32(zone.WithdrawalAddress.Address)
+				icsAddress, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin(zone.LocalDenom, sdk.NewIntFromUint64(2500)))))
 				suite.Require().NoError(appA.BankKeeper.MintCoins(ctx, "mint", sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
 				suite.Require().NoError(appA.BankKeeper.SendCoinsFromModuleToAccount(ctx, "mint", icsAddress, sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewIntFromUint64(900)))))
@@ -307,7 +307,7 @@ func (suite *KeeperTestSuite) TestCalcUserHoldingsAllocations() {
 
 			// distribute assets to users; check remainder (to be distributed next time!)
 			appA.ParticipationRewardsKeeper.DistributeToUsersFromAddress(ctx, icsRewardsAllocations, zone.WithdrawalAddress.Address)
-			icsAddress := sdk.MustAccAddressFromBech32(zone.WithdrawalAddress.Address)
+			icsAddress, _ := addressutils.AddressFromBech32(zone.WithdrawalAddress.Address, "")
 			icsBalance := appA.BankKeeper.GetAllBalances(ctx, icsAddress)
 			suite.Require().ElementsMatch(tt.icsRemainder, icsBalance)
 		})


### PR DESCRIPTION
## 1. Summary
Fixes QCK-502

Replace uses of `sdk.MustAddressFromBech32` with the `addressutils` variant that does not require addresses to start with the local chain's HRP.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
