### PR TITLE
Qck 335 trigger pd creation on zone creation

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -111,7 +111,7 @@ type AppKeepers struct {
 	EpochsKeeper               epochskeeper.Keeper
 	MintKeeper                 mintkeeper.Keeper
 	ClaimsManagerKeeper        claimsmanagerkeeper.Keeper
-	InterchainstakingKeeper    interchainstakingkeeper.Keeper
+	InterchainstakingKeeper    *interchainstakingkeeper.Keeper
 	InterchainQueryKeeper      interchainquerykeeper.Keeper
 	ParticipationRewardsKeeper *participationrewardskeeper.Keeper
 	AirdropKeeper              *airdropkeeper.Keeper

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -609,4 +609,10 @@ func (appKeepers *AppKeepers) SetupHooks() {
 		// insert governance hooks receivers here
 		),
 	)
+
+	appKeepers.InterchainstakingKeeper.SetHooks(
+		interchainstakingtypes.NewMultiIcsHooks(
+			appKeepers.ParticipationRewardsKeeper.Hooks(),
+		),
+	)
 }

--- a/x/airdrop/keeper/keeper.go
+++ b/x/airdrop/keeper/keeper.go
@@ -25,7 +25,7 @@ type Keeper struct {
 	bankKeeper    types.BankKeeper
 	stakingKeeper types.StakingKeeper
 	govKeeper     govkeeper.Keeper
-	icsKeeper     icskeeper.Keeper
+	icsKeeper     *icskeeper.Keeper
 	icqKeeper     icqkeeper.Keeper
 	prKeeper      *prkeeper.Keeper
 
@@ -46,7 +46,7 @@ func NewKeeper(
 	bk types.BankKeeper,
 	sk types.StakingKeeper,
 	gk govkeeper.Keeper,
-	icsk icskeeper.Keeper,
+	icsk *icskeeper.Keeper,
 	icqk icqkeeper.Keeper,
 	prk *prkeeper.Keeper,
 	pofn utils.ProofOpsFn,

--- a/x/interchainstaking/genesis.go
+++ b/x/interchainstaking/genesis.go
@@ -9,7 +9,7 @@ import (
 
 // InitGenesis initializes the interchainstaking module's state from a provided genesis
 // state.
-func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+func InitGenesis(ctx sdk.Context, k *keeper.Keeper, genState types.GenesisState) {
 	k.SetParams(ctx, genState.Params)
 
 	// set registered zones info from genesis
@@ -63,7 +63,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 }
 
 // ExportGenesis returns the capability module's exported genesis.
-func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
+func ExportGenesis(ctx sdk.Context, k *keeper.Keeper) *types.GenesisState {
 	return &types.GenesisState{
 		Params:                 k.GetParams(ctx),
 		Zones:                  k.AllZones(ctx),
@@ -76,7 +76,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	}
 }
 
-func ExportDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegationsForZone {
+func ExportDelegationsPerZone(ctx sdk.Context, k *keeper.Keeper) []types.DelegationsForZone {
 	delegationsForZones := make([]types.DelegationsForZone, 0)
 	k.IterateZones(ctx, func(_ int64, zone *types.Zone) (stop bool) {
 		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zone.ChainId, Delegations: k.GetAllDelegationsAsPointer(ctx, zone)})
@@ -85,7 +85,7 @@ func ExportDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.Delegati
 	return delegationsForZones
 }
 
-func ExportPerformanceDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegationsForZone {
+func ExportPerformanceDelegationsPerZone(ctx sdk.Context, k *keeper.Keeper) []types.DelegationsForZone {
 	delegationsForZones := make([]types.DelegationsForZone, 0)
 	k.IterateZones(ctx, func(_ int64, zone *types.Zone) (stop bool) {
 		delegationsForZones = append(delegationsForZones, types.DelegationsForZone{ChainId: zone.ChainId, Delegations: k.GetAllPerformanceDelegationsAsPointer(ctx, zone)})
@@ -94,7 +94,7 @@ func ExportPerformanceDelegationsPerZone(ctx sdk.Context, k keeper.Keeper) []typ
 	return delegationsForZones
 }
 
-func ExportDelegatorIntentsPerZone(ctx sdk.Context, k keeper.Keeper) []types.DelegatorIntentsForZone {
+func ExportDelegatorIntentsPerZone(ctx sdk.Context, k *keeper.Keeper) []types.DelegatorIntentsForZone {
 	delegatorIntentsForZones := make([]types.DelegatorIntentsForZone, 0)
 	k.IterateZones(ctx, func(_ int64, zone *types.Zone) (stop bool) {
 		// export current epoch intents

--- a/x/interchainstaking/handler.go
+++ b/x/interchainstaking/handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
 )
 
-func NewProposalHandler(k keeper.Keeper) govv1beta1.Handler {
+func NewProposalHandler(k *keeper.Keeper) govv1beta1.Handler {
 	return func(ctx sdk.Context, content govv1beta1.Content) error {
 		switch c := content.(type) {
 		case *types.RegisterZoneProposal:

--- a/x/interchainstaking/ibc_module.go
+++ b/x/interchainstaking/ibc_module.go
@@ -22,11 +22,11 @@ var _ porttypes.IBCModule = IBCModule{}
 
 // IBCModule implements the ICS26 interface for interchain accounts controller chains.
 type IBCModule struct {
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 // NewIBCModule creates a new IBCModule given the keeper.
-func NewIBCModule(k keeper.Keeper) IBCModule {
+func NewIBCModule(k *keeper.Keeper) IBCModule {
 	return IBCModule{
 		keeper: k,
 	}

--- a/x/interchainstaking/keeper/callbacks_test.go
+++ b/x/interchainstaking/keeper/callbacks_test.go
@@ -243,7 +243,7 @@ func (suite *KeeperTestSuite) TestHandleValsetCallback() {
 			bz, err := quicksilver.AppCodec().Marshal(&queryResp)
 			suite.Require().NoError(err)
 
-			err = keeper.ValsetCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
+			err = keeper.ValsetCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
 			suite.Require().NoError(err)
 			// valset callback doesn't actually update validators, but does emit icq callbacks.
 			test.checks(suite.Require(), ctx, quicksilver, chainBVals)
@@ -264,7 +264,7 @@ func (suite *KeeperTestSuite) TestHandleValsetCallbackBadChain() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryResp)
 		suite.Require().NoError(err)
 
-		err = keeper.ValsetCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.ValsetCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		suite.Require().Error(err)
 	})
@@ -283,7 +283,7 @@ func (suite *KeeperTestSuite) TestHandleValsetCallbackNilValset() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryResp)
 		suite.Require().NoError(err)
 
-		err = keeper.ValsetCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
+		err = keeper.ValsetCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		suite.Require().Error(err)
 	})
@@ -302,7 +302,7 @@ func (suite *KeeperTestSuite) TestHandleValsetCallbackInvalidResponse() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryReq)
 		suite.Require().NoError(err)
 
-		err = keeper.ValsetCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
+		err = keeper.ValsetCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		suite.Require().Error(err)
 	})
@@ -321,7 +321,7 @@ func (suite *KeeperTestSuite) TestHandleValidatorCallbackBadChain() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryResp)
 		suite.Require().NoError(err)
 
-		err = keeper.ValidatorCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.ValidatorCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		suite.Require().Error(err)
 	})
@@ -338,7 +338,7 @@ func (suite *KeeperTestSuite) TestHandleValidatorCallbackNilValue() {
 
 		bz := []byte{}
 
-		err := keeper.ValidatorCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
+		err := keeper.ValidatorCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
 		// this should error on unmarshalling an empty slice, which is not a valid response here.
 		suite.Require().Error(err)
 	})
@@ -394,7 +394,7 @@ func (suite *KeeperTestSuite) TestHandleValidatorCallback() {
 			bz, err := quicksilver.AppCodec().Marshal(&test.validator)
 			suite.Require().NoError(err)
 
-			err = keeper.ValidatorCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
+			err = keeper.ValidatorCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
 			suite.Require().NoError(err)
 
 			zone, found := quicksilver.InterchainstakingKeeper.GetZone(ctx, zone.ChainId)
@@ -604,7 +604,7 @@ func (suite *KeeperTestSuite) TestHandleValidatorCallbackJailedWithSlashing() {
 			bz, err := quicksilver.AppCodec().Marshal(test.validator(ctx, quicksilver, zone))
 			suite.Require().NoError(err)
 
-			err = keeper.ValidatorCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
+			err = keeper.ValidatorCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: zone.ChainId})
 			suite.Require().NoError(err)
 
 			wr, found := quicksilver.InterchainstakingKeeper.GetWithdrawalRecord(ctx, suite.chainB.ChainID, test.withdrawal(ctx, quicksilver, zone).Txhash, test.withdrawal(ctx, quicksilver, zone).Status)
@@ -627,7 +627,7 @@ func (suite *KeeperTestSuite) TestHandleRewardsCallbackBadChain() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryRes)
 		suite.Require().NoError(err)
 
-		err = keeper.RewardsCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
+		err = keeper.RewardsCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: "badchain"})
 		// this should bail on a non-matching chain id.
 		suite.Require().Error(err)
 	})
@@ -646,7 +646,7 @@ func (suite *KeeperTestSuite) TestHandleRewardsEmptyRequestCallback() {
 		bz, err := quicksilver.AppCodec().Marshal(&queryReq)
 		suite.Require().NoError(err)
 
-		err = keeper.RewardsCallback(&quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
+		err = keeper.RewardsCallback(quicksilver.InterchainstakingKeeper, ctx, bz, icqtypes.Query{ChainId: suite.chainB.ChainID})
 		// this should fail because the waitgroup becomes negative.
 		suite.Require().Errorf(err, "attempted to unmarshal zero length byte slice (2)")
 	})
@@ -682,7 +682,7 @@ func (suite *KeeperTestSuite) TestHandleRewardsCallbackNonDelegator() {
 
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
-		err = keeper.RewardsCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		//
 		suite.Require().Errorf(err, "failed attempting to withdraw rewards from non-delegation account")
 	})
@@ -711,7 +711,7 @@ func (suite *KeeperTestSuite) TestHandleRewardsCallbackEmptyResponse() {
 
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
-		err = keeper.RewardsCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		//
 		suite.Require().NoError(err)
 	})
@@ -745,7 +745,7 @@ func (suite *KeeperTestSuite) TestHandleValideRewardsCallback() {
 
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
-		err = keeper.RewardsCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.RewardsCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		//
 		suite.Require().NoError(err)
 	})
@@ -772,7 +772,7 @@ func (suite *KeeperTestSuite) TestAllBalancesCallback() {
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		suite.Require().NoError(err)
 
 		// refetch zone
@@ -822,7 +822,7 @@ func (suite *KeeperTestSuite) TestAllBalancesCallbackWithExistingWg() {
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		suite.Require().NoError(err)
 
 		// refetch zone
@@ -875,7 +875,7 @@ func (suite *KeeperTestSuite) TestAllBalancesCallbackExistingBalanceNowNil() {
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		suite.Require().NoError(err)
 
 		// refetch zone
@@ -923,7 +923,7 @@ func (suite *KeeperTestSuite) TestAllBalancesCallbackExistingBalanceNowNil() {
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		suite.Require().NoError(err)
 
 		// refetch zone
@@ -971,7 +971,7 @@ func (suite *KeeperTestSuite) TestAllBalancesCallbackMulti() {
 		respbz, err := quicksilver.AppCodec().Marshal(&response)
 		suite.Require().NoError(err)
 
-		err = keeper.AllBalancesCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
+		err = keeper.AllBalancesCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: reqbz})
 		suite.Require().NoError(err)
 
 		// refetch zone
@@ -1023,7 +1023,7 @@ func (suite *KeeperTestSuite) TestAccountBalanceCallback() {
 			suite.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("qck")...)
 
-			err = keeper.AccountBalanceCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
 			suite.Require().NoError(err)
 		}
 	})
@@ -1053,7 +1053,7 @@ func (suite *KeeperTestSuite) TestAccountBalance046Callback() {
 			suite.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("qck")...)
 
-			err = keeper.AccountBalanceCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
 			suite.Require().NoError(err)
 		}
 	})
@@ -1082,7 +1082,7 @@ func (suite *KeeperTestSuite) TestAccountBalanceCallbackMismatch() {
 			suite.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("stake")...)
 
-			err = keeper.AccountBalanceCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
 			suite.Require().ErrorContains(err, "received coin denom qck does not match requested denom stake")
 		}
 	})
@@ -1111,7 +1111,7 @@ func (suite *KeeperTestSuite) TestAccountBalanceCallbackNil() {
 			suite.Require().NoError(err)
 			data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("stake")...)
 
-			err = keeper.AccountBalanceCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
+			err = keeper.AccountBalanceCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
 			suite.Require().NoError(err)
 		}
 	})
@@ -1130,7 +1130,7 @@ func TestValsetCallbackNilValidatorReqPagination(t *testing.T) {
 	ctx := suite.chainA.GetContext()
 
 	data := []byte("\x12\"\n 00000000000000000000000000000000")
-	err := keeper.ValsetCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
+	err := keeper.ValsetCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
 	suite.Require().NoError(err)
 }
 
@@ -1168,7 +1168,7 @@ func TestDelegationsCallbackAllPresentNoChange(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 
 	suite.Require().NoError(err)
 
@@ -1217,7 +1217,7 @@ func TestDelegationsCallbackAllPresentOneChange(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 
 	suite.Require().NoError(err)
 
@@ -1265,7 +1265,7 @@ func TestDelegationsCallbackOneMissing(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 
 	suite.Require().NoError(err)
 
@@ -1315,7 +1315,7 @@ func TestDelegationsCallbackOneAdditional(t *testing.T) {
 	delegationQuery := stakingtypes.QueryDelegatorDelegationsRequest{DelegatorAddr: zone.DelegationAddress.Address, Pagination: &query.PageRequest{Limit: uint64(len(zone.Validators))}}
 	bz := cdc.MustMarshal(&delegationQuery)
 
-	err := keeper.DelegationsCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err := keeper.DelegationsCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 
 	suite.Require().NoError(err)
 
@@ -1363,7 +1363,7 @@ func TestDelegationCallbackNew(t *testing.T) {
 	suite.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 	suite.Require().NoError(err)
 
 	suite.Require().Equal(4, len(quicksilver.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1402,7 +1402,7 @@ func TestDelegationCallbackUpdate(t *testing.T) {
 	suite.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 	suite.Require().NoError(err)
 
 	suite.Require().Equal(3, len(quicksilver.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1441,7 +1441,7 @@ func TestDelegationCallbackNoOp(t *testing.T) {
 	suite.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 	ctx = suite.chainA.GetContext()
-	err = keeper.DelegationCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 	suite.Require().NoError(err)
 
 	suite.Require().Equal(3, len(quicksilver.InterchainstakingKeeper.GetAllDelegations(ctx, &zone)))
@@ -1480,7 +1480,7 @@ func TestDelegationCallbackRemove(t *testing.T) {
 	suite.Require().NoError(err)
 	bz := stakingtypes.GetDelegationKey(delAddr, valAddr)
 
-	err = keeper.DelegationCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
+	err = keeper.DelegationCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: bz})
 	suite.Require().NoError(err)
 
 	delegationRequests := 0
@@ -1508,7 +1508,7 @@ func TestDepositIntervalCallback(t *testing.T) {
 	quicksilver.InterchainQueryKeeper.IBCKeeper.Codec().MustUnmarshal(data, &res)
 	suite.Require().NoError(err)
 
-	err = keeper.DepositIntervalCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
+	err = keeper.DepositIntervalCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
 	suite.Require().NoError(err)
 	txQueryCount := 0
 	for _, query := range quicksilver.InterchainQueryKeeper.AllQueries(ctx) {
@@ -1553,7 +1553,7 @@ func TestDepositIntervalCallbackWithExistingTxs(t *testing.T) {
 	txrC := res.TxResponses[2]
 	quicksilver.InterchainstakingKeeper.SetReceipt(ctx, icstypes.Receipt{ChainId: suite.chainB.ChainID, Sender: msgC.FromAddress, Txhash: txrC.TxHash, Amount: msgC.Amount})
 
-	err = keeper.DepositIntervalCallback(&quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
+	err = keeper.DepositIntervalCallback(quicksilver.InterchainstakingKeeper, ctx, data, icqtypes.Query{ChainId: suite.chainB.ChainID})
 	suite.Require().NoError(err)
 	txQueryCount := 0
 	for _, query := range quicksilver.InterchainQueryKeeper.AllQueries(ctx) {
@@ -1590,7 +1590,7 @@ func (suite *KeeperTestSuite) TestDelegationAccountBalanceCallback() {
 
 		data := append(banktypes.CreateAccountBalancesPrefix(accAddr), []byte("qck")...)
 
-		err = keeper.DelegationAccountBalanceCallback(&quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
+		err = keeper.DelegationAccountBalanceCallback(quicksilver.InterchainstakingKeeper, ctx, respbz, icqtypes.Query{ChainId: suite.chainB.ChainID, Request: data})
 
 		suite.Require().NoError(err)
 	})

--- a/x/interchainstaking/keeper/fuzz_test.go
+++ b/x/interchainstaking/keeper/fuzz_test.go
@@ -161,6 +161,6 @@ func (suite *FuzzingTestSuite) FuzzValsetCallback(args []byte) {
 	app.InterchainstakingKeeper.CallbackHandler().RegisterCallbacks()
 	ctx := suite.chainA.GetContext()
 
-	err := keeper.ValsetCallback(&app.InterchainstakingKeeper, ctx, args, icqtypes.Query{ChainId: suite.chainB.ChainID})
+	err := keeper.ValsetCallback(app.InterchainstakingKeeper, ctx, args, icqtypes.Query{ChainId: suite.chainB.ChainID})
 	suite.Require().NoError(err)
 }

--- a/x/interchainstaking/keeper/grpc_query_test.go
+++ b/x/interchainstaking/keeper/grpc_query_test.go
@@ -382,7 +382,7 @@ func (suite *KeeperTestSuite) TestKeeper_DelegatorIntents() {
 					LiquidityModule: false,
 					Is_118:          true,
 				}
-				(&icsKeeper).SetZone(ctx, &zone)
+				icsKeeper.SetZone(ctx, &zone)
 				// give funds
 				suite.giveFunds(ctx, zone.LocalDenom, 5000000, testAddress)
 				// set intents

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -50,6 +50,7 @@ type Keeper struct {
 	TransferKeeper      ibctransferkeeper.Keeper
 	ClaimsManagerKeeper claimsmanagerkeeper.Keeper
 	Ir                  codectypes.InterfaceRegistry
+	hooks               types.IcsHooks
 	paramStore          paramtypes.Subspace
 }
 
@@ -91,9 +92,21 @@ func NewKeeper(
 		IBCKeeper:           ibcKeeper,
 		TransferKeeper:      transferKeeper,
 		ClaimsManagerKeeper: claimsManagerKeeper,
+		hooks:               nil,
 
 		paramStore: ps,
 	}
+}
+
+// SetHooks set the ics hooks.
+func (k *Keeper) SetHooks(icsh types.IcsHooks) *Keeper {
+	if k.hooks != nil {
+		panic("cannot set epochs hooks twice")
+	}
+
+	k.hooks = icsh
+
+	return k
 }
 
 func (k *Keeper) GetGovAuthority(_ sdk.Context) string {

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -68,7 +68,7 @@ func NewKeeper(
 	transferKeeper ibctransferkeeper.Keeper,
 	claimsManagerKeeper claimsmanagerkeeper.Keeper,
 	ps paramtypes.Subspace,
-) Keeper {
+) *Keeper {
 	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
 	}
@@ -81,7 +81,7 @@ func NewKeeper(
 		ps = ps.WithKeyTable(types.ParamKeyTable())
 	}
 
-	return Keeper{
+	return &Keeper{
 		cdc:                 cdc,
 		storeKey:            storeKey,
 		scopedKeeper:        scopedKeeper,

--- a/x/interchainstaking/keeper/msg_server_test.go
+++ b/x/interchainstaking/keeper/msg_server_test.go
@@ -280,7 +280,7 @@ func (suite *KeeperTestSuite) TestRequestRedemption() {
 
 			tt.malleate()
 
-			msgSrv := icskeeper.NewMsgServerImpl(suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
+			msgSrv := icskeeper.NewMsgServerImpl(*suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
 			res, err := msgSrv.RequestRedemption(sdk.WrapSDKContext(suite.chainA.GetContext()), &msg)
 
 			if tt.expectErr != "" {
@@ -330,7 +330,7 @@ func (suite *KeeperTestSuite) TestRequestRedemption() {
 
 			tt.malleate()
 
-			msgSrv := icskeeper.NewMsgServerImpl(suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
+			msgSrv := icskeeper.NewMsgServerImpl(*suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
 			res, err := msgSrv.RequestRedemption(sdk.WrapSDKContext(suite.chainA.GetContext()), &msg)
 
 			if tt.expectErrLsm != "" {
@@ -461,7 +461,7 @@ func (suite *KeeperTestSuite) TestSignalIntent() {
 			}
 			suite.Require().NoError(err)
 
-			msgSrv := icskeeper.NewMsgServerImpl(suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
+			msgSrv := icskeeper.NewMsgServerImpl(*suite.GetQuicksilverApp(suite.chainA).InterchainstakingKeeper)
 			res, err := msgSrv.SignalIntent(sdk.WrapSDKContext(suite.chainA.GetContext()), msg)
 			if tt.expectErr {
 				suite.Require().Error(err)

--- a/x/interchainstaking/keeper/proposal_handler.go
+++ b/x/interchainstaking/keeper/proposal_handler.go
@@ -99,6 +99,11 @@ func (k *Keeper) HandleRegisterZoneProposal(ctx sdk.Context, p *types.RegisterZo
 		return err
 	}
 
+	err = k.hooks.AfterZoneCreated(ctx, zone.ConnectionId, zone.ChainId, zone.AccountPrefix)
+	if err != nil {
+		return err
+	}
+
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			sdk.EventTypeMessage,

--- a/x/interchainstaking/module.go
+++ b/x/interchainstaking/module.go
@@ -102,11 +102,11 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 // AppModule implements the AppModule interface for the interchainstaking module.
 type AppModule struct {
 	AppModuleBasic
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 // NewAppModule return a new AppModule.
-func NewAppModule(cdc codec.Codec, k keeper.Keeper) AppModule {
+func NewAppModule(cdc codec.Codec, k *keeper.Keeper) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         k,
@@ -137,8 +137,8 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	// zanicar: this is the only I can find that clearly states that MsgServer
 	// WILL NOT expose gRPC services, and that QueryServer WILL expose gRPC
 	// services;
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), &am.keeper)
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(*am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // RegisterInvariants registers the capability module's invariants.

--- a/x/interchainstaking/types/expected_keepers.go
+++ b/x/interchainstaking/types/expected_keepers.go
@@ -39,5 +39,5 @@ type BankKeeper interface {
 }
 
 type IcsHooks interface {
-	AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error
+	AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error
 }

--- a/x/interchainstaking/types/expected_keepers.go
+++ b/x/interchainstaking/types/expected_keepers.go
@@ -37,3 +37,7 @@ type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
+
+type IcsHooks interface {
+	AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error
+}

--- a/x/interchainstaking/types/hooks.go
+++ b/x/interchainstaking/types/hooks.go
@@ -1,8 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
-// combine multiple staking hooks, all hook functions are run in array sequence
+// combine multiple ics hooks, all hook functions are run in array sequence.
 var _ IcsHooks = &MultiIcsHooks{}
 
 type MultiIcsHooks []IcsHooks
@@ -11,9 +13,9 @@ func NewMultiIcsHooks(hooks ...IcsHooks) MultiIcsHooks {
 	return hooks
 }
 
-func (h MultiIcsHooks) AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error {
+func (h MultiIcsHooks) AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error {
 	for i := range h {
-		if err := h[i].AfterZoneCreated(ctx, connectionId, chainId, accountPrefix); err != nil {
+		if err := h[i].AfterZoneCreated(ctx, connectionID, chainID, accountPrefix); err != nil {
 			return err
 		}
 	}

--- a/x/interchainstaking/types/hooks.go
+++ b/x/interchainstaking/types/hooks.go
@@ -1,0 +1,22 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// combine multiple staking hooks, all hook functions are run in array sequence
+var _ IcsHooks = &MultiIcsHooks{}
+
+type MultiIcsHooks []IcsHooks
+
+func NewMultiIcsHooks(hooks ...IcsHooks) MultiIcsHooks {
+	return hooks
+}
+
+func (h MultiIcsHooks) AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error {
+	for i := range h {
+		if err := h[i].AfterZoneCreated(ctx, connectionId, chainId, accountPrefix); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/x/participationrewards/keeper/hooks.go
+++ b/x/participationrewards/keeper/hooks.go
@@ -93,11 +93,10 @@ func (k *Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64)
 	return nil
 }
 
-func (k *Keeper) AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error {
-
+func (k *Keeper) AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error {
 	connectionPd := types.ConnectionProtocolData{
-		ConnectionID: connectionId,
-		ChainID:      chainId,
+		ConnectionID: connectionID,
+		ChainID:      chainID,
 		LastEpoch:    0,
 		Prefix:       accountPrefix,
 	}
@@ -145,6 +144,6 @@ func (h Hooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumbe
 	return h.k.AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 }
 
-func (h Hooks) AfterZoneCreated(ctx sdk.Context, connectionId, chainId, accountPrefix string) error {
-	return h.k.AfterZoneCreated(ctx, connectionId, chainId, accountPrefix)
+func (h Hooks) AfterZoneCreated(ctx sdk.Context, connectionID, chainID, accountPrefix string) error {
+	return h.k.AfterZoneCreated(ctx, connectionID, chainID, accountPrefix)
 }

--- a/x/participationrewards/keeper/keeper.go
+++ b/x/participationrewards/keeper/keeper.go
@@ -40,7 +40,7 @@ type Keeper struct {
 	bankKeeper           types.BankKeeper
 	stakingKeeper        types.StakingKeeper
 	IcqKeeper            icqkeeper.Keeper
-	icsKeeper            icskeeper.Keeper
+	icsKeeper            *icskeeper.Keeper
 	epochsKeeper         epochskeeper.Keeper
 	feeCollectorName     string
 	prSubmodules         map[cmtypes.ClaimType]Submodule
@@ -58,7 +58,7 @@ func NewKeeper(
 	bk types.BankKeeper,
 	sk types.StakingKeeper,
 	icqk icqkeeper.Keeper,
-	icsk icskeeper.Keeper,
+	icsk *icskeeper.Keeper,
 	feeCollectorName string,
 	proofValidationFn utils.ProofOpsFn,
 	selfProofValidationFn utils.SelfProofOpsFn,


### PR DESCRIPTION
## 1. Summary
Fixes QCK-335

- Add AfterZoneCreated hook on ICS module
- Have AfterZoneCreated created Connection Protocol Data for each newly created zone.
- 
## 2.Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 3. Implementation details

- Add IcsHooks interface to ICS module, with single AfterZoneCreated method, called by the RegisterZone proposal handler.
  - N.B. This requires passing interchainstakingKeeper by pointer into other modules (note: participationRewards and airdrop)
- Have Participation register the AfterZoneCreated hook, to call a function that instantiates and stores a ConnectionProtocolData for the associated zone.

## 4. How to test/use

Run `make build-docker && make test-docker` (or `make test-docker-regen` if not previously generated for v1.4). Once the zone is registered, query: `http://localhost:1317/quicksilver/participationrewards/v1/protocoldata/ProtocolDataTypeConnection/`

This will return a `ProtocolDataTypeConnection` record for `lstest-1` (gaia) in addition to the existing record for `qstest-1` (quicksilver).
