### PR TITLE
quietly ignore nil validator updates, without erroring, to avoid blocking icq

### DIFF
--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -235,6 +235,13 @@ func (k *Keeper) SetValidatorsForZone(ctx sdk.Context, data []byte, icqQuery icq
 }
 
 func (k *Keeper) SetValidatorForZone(ctx sdk.Context, zone *types.Zone, data []byte) error {
+	if data == nil {
+		k.Logger(ctx).Error("expected validator state, got nil")
+		// return nil here, as if we receive nil we fail to unmarshal (as nil validators are invalid),
+		// so we can never hope to resolve this query. Possibly received a valset update from a
+		// different chain.
+		return nil
+	}
 	validator, err := k.UnmarshalValidator(data)
 	if err != nil {
 		k.Logger(ctx).Error("unable to unmarshal validator info for zone", "zone", zone.ChainId, "err", err)


### PR DESCRIPTION
## 1. Summary
Fixes bug where nil validator response is received (query was made for validator that does not exist, valid nil proof delivered) but validator cannot be deleted so bil is never valid from a cosmos PoV.
 
## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

On receipt of `nil` validatorResponse, log error and return nil to allow further messages to be processed.
