### PR TITLE
fix: refactor redelegations distribution logic

### DIFF
--- a/x/interchainstaking/keeper/delegation.go
+++ b/x/interchainstaking/keeper/delegation.go
@@ -202,7 +202,7 @@ func (k *Keeper) PrepareDelegationMessagesForShares(zone *types.Zone, coins sdk.
 }
 
 func (k *Keeper) DeterminePlanForDelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) (map[string]sdkmath.Int, error) {
-	currentAllocations, currentSum, _ := k.GetDelegationMap(ctx, zone)
+	currentAllocations, currentSum, _, _ := k.GetDelegationMap(ctx, zone)
 	targetAllocations, err := k.GetAggregateIntentOrDefault(ctx, zone)
 	if err != nil {
 		return nil, err
@@ -248,25 +248,23 @@ func (k *Keeper) WithdrawDelegationRewardsForResponse(ctx sdk.Context, zone *typ
 	return k.SubmitTx(ctx, msgs, zone.DelegationAddress, "", zone.MessagesPerTx)
 }
 
-func (k *Keeper) GetDelegationMap(ctx sdk.Context, zone *types.Zone) (out map[string]sdkmath.Int, sum sdkmath.Int, locked map[string]bool) {
+func (k *Keeper) GetDelegationMap(ctx sdk.Context, zone *types.Zone) (out map[string]sdkmath.Int, sum sdkmath.Int, locked map[string]bool, lockedSum sdkmath.Int) {
 	out = make(map[string]sdkmath.Int)
 	locked = make(map[string]bool)
 	sum = sdk.ZeroInt()
+	lockedSum = sdk.ZeroInt()
 
 	k.IterateAllDelegations(ctx, zone, func(delegation types.Delegation) bool {
-		existing, found := out[delegation.ValidatorAddress]
-		if !found {
-			out[delegation.ValidatorAddress] = delegation.Amount.Amount
-			locked[delegation.ValidatorAddress] = delegation.RedelegationEnd != 0 && delegation.RedelegationEnd >= ctx.BlockTime().Unix()
-		} else {
-			out[delegation.ValidatorAddress] = existing.Add(delegation.Amount.Amount)
-			locked[delegation.ValidatorAddress] = locked[delegation.ValidatorAddress] || (delegation.RedelegationEnd != 0 && delegation.RedelegationEnd >= ctx.BlockTime().Unix())
+		out[delegation.ValidatorAddress] = delegation.Amount.Amount
+		if delegation.RedelegationEnd >= ctx.BlockTime().Unix() {
+			locked[delegation.ValidatorAddress] = true
+			lockedSum = lockedSum.Add(delegation.Amount.Amount)
 		}
 		sum = sum.Add(delegation.Amount.Amount)
 		return false
 	})
 
-	return out, sum, locked
+	return
 }
 
 func (k *Keeper) MakePerformanceDelegation(ctx sdk.Context, zone *types.Zone, validator string) error {

--- a/x/interchainstaking/keeper/keeper.go
+++ b/x/interchainstaking/keeper/keeper.go
@@ -630,12 +630,12 @@ func (k *Keeper) GetAggregateIntentOrDefault(ctx sdk.Context, z *types.Zone) (ty
 }
 
 func (k *Keeper) Rebalance(ctx sdk.Context, zone *types.Zone, epochNumber int64) error {
-	currentAllocations, currentSum, currentLocked := k.GetDelegationMap(ctx, zone)
+	currentAllocations, currentSum, currentLocked, lockedSum := k.GetDelegationMap(ctx, zone)
 	targetAllocations, err := k.GetAggregateIntentOrDefault(ctx, zone)
 	if err != nil {
 		return err
 	}
-	rebalances := types.DetermineAllocationsForRebalancing(currentAllocations, currentLocked, currentSum, targetAllocations, k.ZoneRedelegationRecords(ctx, zone.ChainId), k.Logger(ctx))
+	rebalances := types.DetermineAllocationsForRebalancing(currentAllocations, currentLocked, currentSum, lockedSum, targetAllocations, k.Logger(ctx))
 	msgs := make([]sdk.Msg, 0)
 	for _, rebalance := range rebalances {
 		msgs = append(msgs, &stakingtypes.MsgBeginRedelegate{DelegatorAddress: zone.DelegationAddress.Address, ValidatorSrcAddress: rebalance.Source, ValidatorDstAddress: rebalance.Target, Amount: sdk.NewCoin(zone.BaseDenom, rebalance.Amount)})

--- a/x/interchainstaking/keeper/redemptions.go
+++ b/x/interchainstaking/keeper/redemptions.go
@@ -272,7 +272,7 @@ func (k *Keeper) GCCompletedUnbondings(ctx sdk.Context, zone *types.Zone) error 
 }
 
 func (k *Keeper) DeterminePlanForUndelegation(ctx sdk.Context, zone *types.Zone, amount sdk.Coins) (map[string]math.Int, error) {
-	currentAllocations, currentSum, _ := k.GetDelegationMap(ctx, zone)
+	currentAllocations, currentSum, _, _ := k.GetDelegationMap(ctx, zone)
 	availablePerValidator, _, err := k.GetUnlockedTokensForZone(ctx, zone)
 	if err != nil {
 		return nil, err

--- a/x/interchainstaking/types/rebalance.go
+++ b/x/interchainstaking/types/rebalance.go
@@ -57,139 +57,186 @@ func CalculateDeltas(currentAllocations map[string]sdkmath.Int, currentSum sdkma
 	return deltas
 }
 
+// CalculateDeltas determines, for the current delegations, in delta between actual allocations and the target intent.
+// Positive delta represents current allocation is below target, and vice versa.
+func CalculateDeltasNew(currentAllocations map[string]sdkmath.Int, locked map[string]bool, currentSum sdkmath.Int, targetAllocations ValidatorIntents) (targets, sources Deltas) {
+	targets = make(Deltas, 0)
+	sources = make(Deltas, 0)
+
+	targetValopers := func(in ValidatorIntents) []string {
+		out := make([]string, 0, len(in))
+		for _, i := range in {
+			out = append(out, i.ValoperAddress)
+		}
+		return out
+	}(targetAllocations)
+
+	keySet := utils.Unique(append(targetValopers, utils.Keys(currentAllocations)...))
+	sort.Strings(keySet)
+	// for target allocations, raise the intent weight by the total delegated value to get target amount
+	for _, valoper := range keySet {
+		current, ok := currentAllocations[valoper]
+		if !ok {
+			current = sdk.ZeroInt()
+		}
+
+		target, ok := targetAllocations.GetForValoper(valoper)
+		if !ok {
+			target = &ValidatorIntent{ValoperAddress: valoper, Weight: sdk.ZeroDec()}
+		}
+		targetAmount := target.Weight.MulInt(currentSum).TruncateInt()
+		// diff between target and current allocations
+		// positive == below target, negative == above target
+		delta := targetAmount.Sub(current)
+
+		if delta.IsPositive() {
+			targets = append(targets, &Delta{Amount: delta, ValoperAddress: valoper})
+		} else {
+			if _, found := locked[valoper]; !found {
+				// only append to sources if the delegation is not locked - i.e. it doesn't have an incoming redelegation.
+				sources = append(sources, &Delta{Amount: delta.Abs(), ValoperAddress: valoper})
+			}
+		}
+	}
+
+	targets.Sort()
+	sources.Sort()
+
+	return
+}
+
+type Delta struct {
+	ValoperAddress string
+	Amount         sdkmath.Int
+}
+
+type Deltas []*Delta
+
+func (d Deltas) Sort() {
+
+	// filter zeros
+	new := make(Deltas, 0)
+	for _, delta := range d {
+		if !delta.Amount.IsZero() {
+			new = append(new, delta)
+		}
+	}
+	d = new
+
+	// sort keys by relative value of delta
+	sort.SliceStable(d, func(i, j int) bool {
+		// < sorts alphabetically.
+		return d[i].ValoperAddress < d[j].ValoperAddress
+	})
+
+	// sort keys by relative value of delta
+	sort.SliceStable(d, func(i, j int) bool {
+		return d[i].Amount.GT(d[j].Amount)
+	})
+}
+
 type RebalanceTarget struct {
 	Amount sdkmath.Int
 	Source string
 	Target string
 }
 
+type RebalanceTargets []*RebalanceTarget
+
+func (t RebalanceTargets) Sort() {
+	// sort keys by relative value of delta
+	sort.SliceStable(t, func(i, j int) bool {
+		// < sorts alphabetically.
+		return t[i].Source < t[j].Source
+	})
+
+	// sort keys by relative value of delta
+	sort.SliceStable(t, func(i, j int) bool {
+		// < sorts alphabetically.
+		return t[i].Target < t[j].Target
+	})
+
+	// sort keys by relative value of delta
+	sort.SliceStable(t, func(i, j int) bool {
+		return t[i].Amount.LT(t[j].Amount)
+	})
+}
+
+// DetermineAllocationsForRebalancing takes
 func DetermineAllocationsForRebalancing(
 	currentAllocations map[string]sdkmath.Int,
 	currentLocked map[string]bool,
 	currentSum sdkmath.Int,
+	lockedSum sdkmath.Int,
 	targetAllocations ValidatorIntents,
-	existingRedelegations []RedelegationRecord,
 	logger log.Logger,
-) []RebalanceTarget {
-	out := make([]RebalanceTarget, 0)
-	deltas := CalculateDeltas(currentAllocations, currentSum, targetAllocations)
+) RebalanceTargets {
+	out := make(RebalanceTargets, 0)
+	targets, sources := CalculateDeltasNew(currentAllocations, currentLocked, currentSum, targetAllocations)
 
-	wantToRebalance := sdk.ZeroInt()
-	canRebalanceFrom := sdk.ZeroInt()
+	// rebalanceBudget = (total_delegations - locked)/2 == 50% of (total_delegations - locked)
+	// TODO: make this 2 (max_redelegation_factor) a param.
+	rebalanceBudget := currentSum.Sub(lockedSum).Quo(sdk.NewInt(2))
 
-	totalLocked := int64(0)
-	lockedPerValidator := map[string]int64{}
-	for _, redelegation := range existingRedelegations {
-		totalLocked += redelegation.Amount
-		thisLocked, found := lockedPerValidator[redelegation.Destination]
-		if !found {
-			thisLocked = 0
-		}
-		lockedPerValidator[redelegation.Destination] = thisLocked + redelegation.Amount
-	}
-	for _, valoper := range utils.Keys(currentAllocations) {
-		// if validator already has a redelegation _to_ it, we can no longer redelegate _from_ it (transitive redelegations)
-		// remove _locked_ amount from lpv and total locked for purposes of rebalancing.
-		if currentLocked[valoper] {
-			thisLocked, found := lockedPerValidator[valoper]
-			if !found {
-				thisLocked = 0
-			}
-			totalLocked = totalLocked - thisLocked + currentAllocations[valoper].Int64()
-			lockedPerValidator[valoper] = currentAllocations[valoper].Int64()
-		}
-	}
-
-	// TODO: make these params
-	maxCanRebalanceTotal := currentSum.Sub(sdkmath.NewInt(totalLocked)).Quo(sdk.NewInt(2))
-	maxCanRebalance := sdkmath.MinInt(maxCanRebalanceTotal, currentSum.Quo(sdk.NewInt(7)))
 	if logger != nil {
-		logger.Debug("Rebalancing", "totalLocked", totalLocked, "lockedPerValidator", lockedPerValidator, "canRebalanceTotal", maxCanRebalanceTotal, "canRebalanceEpoch", maxCanRebalance)
+		logger.Debug("Rebalancing", "total", currentSum, "totalLocked", lockedSum, "rebalanceBudget", rebalanceBudget)
 	}
 
-	// deltas are sorted in CalculateDeltas; don't re-sort.
-	for _, delta := range deltas {
-		switch {
-		case delta.Weight.IsZero():
-			// do nothing
-		case delta.Weight.IsPositive():
-			// if delta > current value - locked value, truncate, as we cannot rebalance locked tokens.
-			wantToRebalance = wantToRebalance.Add(delta.Weight.TruncateInt())
-		case delta.Weight.IsNegative():
-			if delta.Weight.Abs().GT(sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(sdkmath.NewInt(lockedPerValidator[delta.ValoperAddress])))) {
-				delta.Weight = sdk.NewDecFromInt(currentAllocations[delta.ValoperAddress].Sub(sdkmath.NewInt(lockedPerValidator[delta.ValoperAddress]))).Neg()
-				if logger != nil {
-					logger.Debug("Truncated delta due to locked tokens", "valoper", delta.ValoperAddress, "delta", delta.Weight.Abs())
+TARGET:
+	// targets are validators with a delegation deficit, sorted in descending order.
+	// that is, those at the top should be satisfied first to maximise progress toward goal.
+	for _, target := range targets {
+		// amount is amount we should try to redelegate toward target. This may be constrained by the remaining redelegateBudget.
+		// if it is zero (i.e. we hit the redelegation budget) break out of the loop.
+		amount := sdkmath.MinInt(target.Amount, rebalanceBudget)
+		if amount.IsZero() {
+			break
+		}
+		sources.Sort()
+		// sources are validators with available balance to redelegate, sorted in desc order.
+		for _, source := range sources {
+			switch {
+			case source.Amount.IsZero():
+				// if source is zero, skip.
+				continue
+			case source.Amount.GTE(amount):
+				// if source >= amount, fully satisfy target.
+				out = append(out, &RebalanceTarget{Amount: amount, Target: target.ValoperAddress, Source: source.ValoperAddress})
+				source.Amount = source.Amount.Sub(amount)
+				target.Amount = target.Amount.Sub(amount)
+				rebalanceBudget = rebalanceBudget.Sub(amount)
+				continue TARGET
+			case source.Amount.LT(amount):
+				// if source < amount, partially satisfy amount.
+				out = append(out, &RebalanceTarget{Amount: source.Amount, Target: target.ValoperAddress, Source: source.ValoperAddress})
+				amount = amount.Sub(source.Amount)
+				target.Amount = target.Amount.Sub(source.Amount)
+				rebalanceBudget = rebalanceBudget.Sub(source.Amount)
+				source.Amount = source.Amount.Sub(source.Amount)
+				if amount.IsZero() || rebalanceBudget.IsZero() {
+					// if the amount is fully satisfied or the rebalanceBudget is zero, skip to next target.
+					continue TARGET
 				}
+				// otherwise, try next source.
 			}
-			canRebalanceFrom = canRebalanceFrom.Add(delta.Weight.Abs().TruncateInt())
 		}
-	}
-
-	toRebalance := sdk.MinInt(sdk.MinInt(wantToRebalance, canRebalanceFrom), maxCanRebalance)
-
-	if toRebalance.Equal(sdkmath.ZeroInt()) {
+		// we only get here if we are unable to satisfy targets due to rebalanceBudget depletion.
 		if logger != nil {
-			logger.Debug("No rebalancing this epoch")
+			logger.Info("unable to satisfy targets with available sources.")
 		}
-		return []RebalanceTarget{}
-	}
-	if logger != nil {
-		logger.Debug("Will rebalance this epoch", "amount", toRebalance)
 	}
 
-	tgtIdx := 0
-	srcIdx := len(deltas) - 1
-	for i := 0; toRebalance.GT(sdk.ZeroInt()); {
-		i++
-		if i > 20 {
-			break
-		}
-		src := deltas[srcIdx]
-		tgt := deltas[tgtIdx]
-		if src.ValoperAddress == tgt.ValoperAddress {
-			break
-		}
-		var amount sdkmath.Int
-		if src.Weight.Abs().TruncateInt().IsZero() { //nolint:gocritic
-			srcIdx--
-			continue
-		} else if src.Weight.Abs().TruncateInt().GT(toRebalance) { // amount == rebalance
-			amount = toRebalance
-		} else {
-			amount = src.Weight.Abs().TruncateInt()
-		}
-
-		if tgt.Weight.Abs().TruncateInt().IsZero() {
-			tgtIdx++
-			continue
-		} else if tgt.Weight.Abs().TruncateInt().LTE(toRebalance) {
-			amount = sdk.MinInt(amount, tgt.Weight.Abs().TruncateInt())
-		}
-
-		out = append(out, RebalanceTarget{Amount: amount, Target: tgt.ValoperAddress, Source: src.ValoperAddress})
-		deltas[srcIdx].Weight = src.Weight.Add(sdk.NewDecFromInt(amount))
-		deltas[tgtIdx].Weight = tgt.Weight.Sub(sdk.NewDecFromInt(amount))
-		toRebalance = toRebalance.Sub(amount)
-
-	}
-
-	// sort keys by relative value of delta
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Source < out[j].Source
-	})
-
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Target < out[j].Target
-	})
-
-	// sort keys by relative value of delta
-	sort.SliceStable(out, func(i, j int) bool {
-		return out[i].Amount.GT(out[j].Amount)
-	})
+	out.Sort()
 
 	return out
 }
+
+// func (d Deltas) Render() (out string) {
+// 	for _, delta := range d {
+// 		out = out + fmt.Sprintf("%s:\t%d\n", delta.ValoperAddress, delta.Amount.Int64())
+// 	}
+// 	return
+// }
 
 // MinDeltas returns the lowest value in a slice of Deltas.
 func MinDeltas(deltas ValidatorIntents) sdkmath.Int {

--- a/x/interchainstaking/types/rebalance_test.go
+++ b/x/interchainstaking/types/rebalance_test.go
@@ -1,0 +1,396 @@
+package types_test
+
+import (
+	"sort"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ingenuity-build/quicksilver/utils/addressutils"
+	"github.com/ingenuity-build/quicksilver/x/interchainstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func GenerateDeterministicValidators(n int) (out []string) {
+	out = make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, addressutils.GenerateAddressForTestWithPrefix("cosmosvaloper"))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestDetermineAllocationsForRebalancing(t *testing.T) {
+	vals := GenerateDeterministicValidators(5)
+
+	type testcase struct {
+		name        string
+		allocations map[string]math.Int
+		target      types.ValidatorIntents
+		locked      map[string]bool
+		expected    types.RebalanceTargets
+	}
+
+	tcs := []testcase{
+		{
+			name: "100% No Existing Redelegations",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(10),
+				vals[1]: math.NewInt(10),
+				vals[2]: math.NewInt(10),
+				vals[3]: math.NewInt(10),
+				vals[4]: math.NewInt(10),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDec(1),
+				},
+			},
+			locked: map[string]bool{},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[1],
+					Target: vals[0],
+					Amount: math.NewInt(10),
+				},
+				{
+					Source: vals[2],
+					Target: vals[0],
+					Amount: math.NewInt(10),
+				},
+				{
+					Source: vals[3],
+					Target: vals[0],
+					Amount: math.NewInt(5),
+				},
+			},
+		},
+		{
+			name: "50/50 No Existing Redelegations, Constrained by total",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(10),
+				vals[1]: math.NewInt(10),
+				vals[2]: math.NewInt(10),
+				vals[3]: math.NewInt(10),
+				vals[4]: math.NewInt(10),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			locked: map[string]bool{},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[2],
+					Target: vals[0],
+					Amount: math.NewInt(10),
+				},
+				{
+					Source: vals[3],
+					Target: vals[0],
+					Amount: math.NewInt(5),
+				},
+				{
+					Source: vals[3],
+					Target: vals[1],
+					Amount: math.NewInt(5),
+				},
+				{
+					Source: vals[4],
+					Target: vals[1],
+					Amount: math.NewInt(5),
+				},
+			},
+		},
+		{
+			name: "50/50 No Existing Redelegations, Unconstrained",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(10),
+				vals[1]: math.NewInt(10),
+				vals[2]: math.NewInt(10),
+				vals[3]: math.NewInt(10),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			locked: map[string]bool{},
+			expected: []*types.RebalanceTarget{
+				{
+					Source: vals[2],
+					Target: vals[0],
+					Amount: math.NewInt(10),
+				},
+				{
+					Source: vals[3],
+					Target: vals[1],
+					Amount: math.NewInt(10),
+				},
+			},
+		},
+		{
+			name: "Drop one validator, No Existing Redelegations",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(8),
+				vals[1]: math.NewInt(8),
+				vals[2]: math.NewInt(8),
+				vals[3]: math.NewInt(8),
+				vals[4]: math.NewInt(8),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(25, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(25, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[2],
+					Weight:         sdk.NewDecWithPrec(25, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[3],
+					Weight:         sdk.NewDecWithPrec(25, 2),
+				},
+			},
+			locked: map[string]bool{},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[4],
+					Target: vals[0],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[4],
+					Target: vals[1],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[4],
+					Target: vals[2],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[4],
+					Target: vals[3],
+					Amount: math.NewInt(2),
+				},
+			},
+		},
+		{
+			name: "Add one validator, No Existing Redelegations",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(10),
+				vals[1]: math.NewInt(10),
+				vals[2]: math.NewInt(10),
+				vals[3]: math.NewInt(10),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(20, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(20, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[2],
+					Weight:         sdk.NewDecWithPrec(20, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[3],
+					Weight:         sdk.NewDecWithPrec(20, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[4],
+					Weight:         sdk.NewDecWithPrec(20, 2),
+				},
+			},
+			locked: map[string]bool{},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[0],
+					Target: vals[4],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[1],
+					Target: vals[4],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[2],
+					Target: vals[4],
+					Amount: math.NewInt(2),
+				},
+				{
+					Source: vals[3],
+					Target: vals[4],
+					Amount: math.NewInt(2),
+				},
+			},
+		},
+		{
+			name: "Attempt redelegate away from locked validator; no-op",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(10),
+				vals[1]: math.NewInt(10),
+				vals[2]: math.NewInt(10),
+				vals[3]: math.NewInt(10),
+				vals[4]: math.NewInt(10),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(10, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(225, 3),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[2],
+					Weight:         sdk.NewDecWithPrec(225, 3),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[3],
+					Weight:         sdk.NewDecWithPrec(225, 3),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[4],
+					Weight:         sdk.NewDecWithPrec(225, 3),
+				},
+			},
+			locked: map[string]bool{
+				vals[0]: true,
+			},
+			expected: types.RebalanceTargets{},
+		},
+		{
+			name: "Delegate away from 2; 1 locked validator; v1 -15; v2 + 10; v3 +5",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(20),
+				vals[1]: math.NewInt(20),
+				vals[2]: math.NewInt(20),
+				vals[3]: math.NewInt(20),
+				vals[4]: math.NewInt(20),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[0],
+					Weight:         sdk.NewDecWithPrec(5, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.NewDecWithPrec(5, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[2],
+					Weight:         sdk.NewDecWithPrec(30, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[3],
+					Weight:         sdk.NewDecWithPrec(30, 2),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[4],
+					Weight:         sdk.NewDecWithPrec(30, 2),
+				},
+			},
+			locked: map[string]bool{
+				vals[0]: true,
+			},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[1],
+					Target: vals[2],
+					Amount: math.NewInt(10),
+				},
+				{
+					Source: vals[1],
+					Target: vals[3],
+					Amount: math.NewInt(5),
+				},
+			},
+		},
+		{
+			name: "v0 missing, v1 zero; one new vals. Should delegate v0: -50; v1: -25; v2: +25; v3: +50",
+			allocations: map[string]math.Int{
+				vals[0]: math.NewInt(50),
+				vals[1]: math.NewInt(50),
+				vals[2]: math.NewInt(50),
+			},
+			target: types.ValidatorIntents{
+				&types.ValidatorIntent{
+					ValoperAddress: vals[1],
+					Weight:         sdk.ZeroDec(),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[2],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+				&types.ValidatorIntent{
+					ValoperAddress: vals[3],
+					Weight:         sdk.NewDecWithPrec(5, 1),
+				},
+			},
+			locked: map[string]bool{},
+			expected: types.RebalanceTargets{
+				{
+					Source: vals[0],
+					Target: vals[2],
+					Amount: math.NewInt(25),
+				},
+				{
+					Source: vals[0],
+					Target: vals[3],
+					Amount: math.NewInt(25),
+				},
+				{
+					Source: vals[1],
+					Target: vals[3],
+					Amount: math.NewInt(25),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tcs {
+		t.Run(tt.name, func(t *testing.T) {
+
+			currentSum, lockedSum := func(in map[string]math.Int, locked map[string]bool) (sum, lockedsum math.Int) {
+				sum = math.ZeroInt()
+				lockedsum = math.ZeroInt()
+				for k, v := range in {
+					sum = sum.Add(v)
+					if locked[k] {
+						lockedsum = lockedsum.Add(v)
+					}
+				}
+				return
+			}(tt.allocations, tt.locked)
+
+			actual := types.DetermineAllocationsForRebalancing(
+				tt.allocations, tt.locked, currentSum, lockedSum, tt.target, nil,
+			)
+
+			require.ElementsMatch(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## 1. Summary
Remove complexity and improve readability in rebalancing.

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

Rewrite logic for readability and efficiency; don't handle locked tokens twice (potential bug?).

Use specific Delta types instead of trying to reuse ValidatorIntents and casting between Dec and Int all of the place 🤮 

## 6. Limitations

Currently only affects redelegations. Deposit and unbonding logic uses legacy distribution.

## 7. Future Work (optional)

Update deposits and unbonding to use the new types and logic.