### PR TITLE
fix: ics rewards take 4 😢 

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -314,8 +314,11 @@ func (k *Keeper) HandleMsgTransfer(ctx sdk.Context, msg sdk.Msg) error {
 	receivedCoin := sMsg.Token
 
 	zone, found := k.GetZoneForWithdrawalAccount(ctx, sMsg.Sender)
+	if !found {
+		return fmt.Errorf("zone not found for withdrawal account %s", sMsg.Sender)
+	}
 
-	var channel *channeltypes.IdentifiedChannel = nil
+	var channel *channeltypes.IdentifiedChannel
 	k.IBCKeeper.ChannelKeeper.IterateChannels(ctx, func(ic channeltypes.IdentifiedChannel) bool {
 		if ic.Counterparty.ChannelId == sMsg.SourceChannel && ic.Counterparty.PortId == sMsg.SourcePort && len(ic.ConnectionHops) == 1 && ic.ConnectionHops[0] == zone.ConnectionId {
 			channel = &ic

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -315,13 +315,21 @@ func (k *Keeper) HandleMsgTransfer(ctx sdk.Context, msg sdk.Msg) error {
 
 	zone, found := k.GetZoneForWithdrawalAccount(ctx, sMsg.Sender)
 
-	channel, cfound := k.IBCKeeper.ChannelKeeper.GetChannel(ctx, sMsg.SourcePort, sMsg.SourceChannel)
-	if !cfound {
+	var channel *channeltypes.IdentifiedChannel = nil
+	k.IBCKeeper.ChannelKeeper.IterateChannels(ctx, func(ic channeltypes.IdentifiedChannel) bool {
+		if ic.Counterparty.ChannelId == sMsg.SourceChannel && ic.Counterparty.PortId == sMsg.SourcePort && len(ic.ConnectionHops) == 1 && ic.ConnectionHops[0] == zone.ConnectionId {
+			channel = &ic
+			return true
+		}
+		return false
+	})
+
+	if channel == nil {
 		k.Logger(ctx).Error("channel not found for the packet", "port", sMsg.SourcePort, "channel", sMsg.SourceChannel)
 		return errors.New("channel not found for the packet")
 	}
 
-	denomTrace := utils.DeriveIbcDenomTrace(channel.Counterparty.PortId, channel.Counterparty.ChannelId, receivedCoin.Denom)
+	denomTrace := utils.DeriveIbcDenomTrace(channel.PortId, channel.ChannelId, receivedCoin.Denom)
 	receivedCoin.Denom = denomTrace.IBCDenom()
 
 	if found && denomTrace.BaseDenom != zone.BaseDenom {
@@ -374,7 +382,7 @@ func (k *Keeper) HandleCompleteSend(ctx sdk.Context, msg sdk.Msg, memo string) e
 	case zone.IsDelegateAddress(sMsg.ToAddress) && zone.DepositAddress.Address == sMsg.FromAddress:
 		return k.handleSendToDelegate(ctx, zone, sMsg, memo)
 	default:
-		err = errors.New("unexpected completed send")
+		err = fmt.Errorf("unexpected completed send (2) from %s to %s (amount: %s)", sMsg.FromAddress, sMsg.ToAddress, sMsg.Amount)
 		k.Logger(ctx).Error(err.Error())
 		return err
 	}
@@ -758,9 +766,9 @@ func (k *Keeper) HandleFailedBankSend(ctx sdk.Context, msg sdk.Msg, memo string)
 		// MsgSend from deposit account to delegate account for deposit.
 		k.Logger(ctx).Error("MsgSend from deposit account to delegate account failed")
 	default:
-		err = errors.New("unexpected completed send")
+		err = fmt.Errorf("unexpected completed send (1) from %s to %s (amount: %s)", sMsg.FromAddress, sMsg.ToAddress, sMsg.Amount)
 		k.Logger(ctx).Error(err.Error())
-		return err
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
- ack is from the perspective of the host zone, so we need the local channel/port based upon counterparty; sadly iteration it is. 
- also add better logging for unidentified msgSends; ignore error quietly if failure of unknown origin

- requires tests to be fixed