### PR TITLE
Parse memo before looking up hash

### DIFF
--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -438,7 +438,6 @@ func (k *Keeper) HandleWithdrawForUser(ctx sdk.Context, zone *types.Zone, msg *b
 			// if we can't burn the coins, fail.
 			return err
 		}
-		k.SetWithdrawalRecord(ctx, withdrawalRecord)
 		k.Logger(ctx).Info("burned coins post-withdrawal", "coins", withdrawalRecord.BurnAmount)
 	} else {
 
@@ -457,7 +456,6 @@ func (k *Keeper) HandleWithdrawForUser(ctx sdk.Context, zone *types.Zone, msg *b
 						// if we can't burn the coins, fail.
 						return err
 					}
-					k.SetWithdrawalRecord(ctx, withdrawalRecord)
 					k.Logger(ctx).Info("burned coins post-withdrawal", "coins", withdrawalRecord.BurnAmount)
 				}
 				break

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -419,7 +419,12 @@ func (k *Keeper) handleSendToDelegate(ctx sdk.Context, zone *types.Zone, msg *ba
 // if no other withdrawal records exist for this triple (i.e. no further withdrawal from this delegator account for this user (i.e. different validator))
 // then burn the withdrawal_record's burn_amount.
 func (k *Keeper) HandleWithdrawForUser(ctx sdk.Context, zone *types.Zone, msg *banktypes.MsgSend, memo string) error {
-	withdrawalRecord, found := k.GetWithdrawalRecord(ctx, zone.ChainId, memo, types.WithdrawStatusSend)
+	txHash, err := types.ParseTxMsgMemo(memo, types.MsgTypeUnbondSend)
+	if err != nil {
+		return err
+	}
+
+	withdrawalRecord, found := k.GetWithdrawalRecord(ctx, zone.ChainId, txHash, types.WithdrawStatusSend)
 	if !found {
 		return errors.New("no matching withdrawal record found")
 	}

--- a/x/interchainstaking/keeper/ibc_packet_handlers_test.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers_test.go
@@ -518,7 +518,7 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUser() {
 				}
 			},
 			message: banktypes.MsgSend{},
-			memo:    "7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
+			memo:    "unbondSend/7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
 			err:     true,
 		},
 		{
@@ -545,7 +545,7 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUser() {
 			message: banktypes.MsgSend{
 				Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(4000000))),
 			},
-			memo: "7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
+			memo: "unbondSend/7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
 			err:  false,
 		},
 		{
@@ -587,7 +587,7 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUser() {
 			message: banktypes.MsgSend{
 				Amount: sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(15000000))),
 			},
-			memo: "d786f7d4c94247625c2882e921a790790eb77a00d0534d5c3154d0a9c5ab68f5",
+			memo: "unbondSend/d786f7d4c94247625c2882e921a790790eb77a00d0534d5c3154d0a9c5ab68f5",
 			err:  false,
 		},
 	}
@@ -625,14 +625,14 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUser() {
 			}
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusSend, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash == test.memo {
+				if withdrawal.Txhash == test.memo[11:] {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
 			})
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusCompleted, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash != test.memo {
+				if withdrawal.Txhash != test.memo[11:] {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
@@ -674,7 +674,7 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUserLSM() {
 				{Amount: sdk.NewCoins(sdk.NewCoin(v1+"1", sdk.NewInt(1000000)))},
 				{Amount: sdk.NewCoins(sdk.NewCoin(v2+"2", sdk.NewInt(1000000)))},
 			},
-			memo: "7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
+			memo: "unbondSend/7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
 			err:  false,
 		},
 		{
@@ -700,7 +700,7 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUserLSM() {
 				{Amount: sdk.NewCoins(sdk.NewCoin(v2+"1", sdk.NewInt(1500000)))},
 				{Amount: sdk.NewCoins(sdk.NewCoin(v1+"2", sdk.NewInt(1000000)))},
 			},
-			memo: "7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
+			memo: "unbondSend/7C8B95EEE82CB63771E02EBEB05E6A80076D70B2E0A1C457F1FD1A0EF2EA961D",
 			err:  false,
 		},
 	}
@@ -741,14 +741,14 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUserLSM() {
 			}
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusSend, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash == test.memo {
+				if withdrawal.Txhash == test.memo[11:] {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
 			})
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusCompleted, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash != test.memo {
+				if withdrawal.Txhash != test.memo[11:] {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false

--- a/x/interchainstaking/keeper/ibc_packet_handlers_test.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers_test.go
@@ -624,15 +624,18 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUser() {
 				suite.Require().NoError(err)
 			}
 
+			hash, err := icstypes.ParseTxMsgMemo(test.memo, icstypes.MsgTypeUnbondSend)
+			suite.Require().NoError(err)
+
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusSend, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash == test.memo[11:] {
+				if withdrawal.Txhash == hash {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
 			})
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusCompleted, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash != test.memo[11:] {
+				if withdrawal.Txhash != hash {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
@@ -740,15 +743,18 @@ func (suite *KeeperTestSuite) TestHandleWithdrawForUserLSM() {
 				}
 			}
 
+			hash, err := icstypes.ParseTxMsgMemo(test.memo, icstypes.MsgTypeUnbondSend)
+			suite.Require().NoError(err)
+
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusSend, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash == test.memo[11:] {
+				if withdrawal.Txhash == hash {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false
 			})
 
 			quicksilver.InterchainstakingKeeper.IterateZoneStatusWithdrawalRecords(ctx, zone.ChainId, icstypes.WithdrawStatusCompleted, func(idx int64, withdrawal icstypes.WithdrawalRecord) bool {
-				if withdrawal.Txhash != test.memo[11:] {
+				if withdrawal.Txhash != hash {
 					suite.Require().Fail("unexpected withdrawal record; status should be Completed.")
 				}
 				return false


### PR DESCRIPTION
## 1. Summary
Fixes issue with completed unbondings where memo is not parseable after change in format.

## 2.Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

ParseMemo field to correctly remove unbond/ prefix.
