### PR TITLE
fix possible nil performance address panic in participation rewards

### DIFF
--- a/x/participationrewards/keeper/rewards_validatorSelection.go
+++ b/x/participationrewards/keeper/rewards_validatorSelection.go
@@ -17,23 +17,25 @@ import (
 // individually in a callback.
 func (k Keeper) AllocateValidatorSelectionRewards(ctx sdk.Context) {
 	k.icsKeeper.IterateZones(ctx, func(_ int64, zone *icstypes.Zone) (stop bool) {
-		k.Logger(ctx).Info("zones", "chain_id", zone.ChainId, "performance address", zone.PerformanceAddress.Address)
+		if zone.PerformanceAddress != nil {
+			k.Logger(ctx).Info("zones", "chain_id", zone.ChainId, "performance address", zone.PerformanceAddress.Address)
 
-		// obtain zone performance account rewards
-		rewardsQuery := distrtypes.QueryDelegationTotalRewardsRequest{DelegatorAddress: zone.PerformanceAddress.Address}
-		bz := k.cdc.MustMarshal(&rewardsQuery)
+			// obtain zone performance account rewards
+			rewardsQuery := distrtypes.QueryDelegationTotalRewardsRequest{DelegatorAddress: zone.PerformanceAddress.Address}
+			bz := k.cdc.MustMarshal(&rewardsQuery)
 
-		k.IcqKeeper.MakeRequest(
-			ctx,
-			zone.ConnectionId,
-			zone.ChainId,
-			"cosmos.distribution.v1beta1.Query/DelegationTotalRewards",
-			bz,
-			sdk.NewInt(-1),
-			types.ModuleName,
-			ValidatorSelectionRewardsCallbackID,
-			0,
-		)
+			k.IcqKeeper.MakeRequest(
+				ctx,
+				zone.ConnectionId,
+				zone.ChainId,
+				"cosmos.distribution.v1beta1.Query/DelegationTotalRewards",
+				bz,
+				sdk.NewInt(-1),
+				types.ModuleName,
+				ValidatorSelectionRewardsCallbackID,
+				0,
+			)
+		}
 		return false
 	})
 }


### PR DESCRIPTION
## 1. Summary
Fixes panic in participationrewards epoch hook where performance account has not been initialised.
