### PR TITLE
fix: handle redelegation ack

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -21,7 +21,7 @@ const (
 	v010209UpgradeName  = "v1.2.9"
 	v0102010UpgradeName = "v1.2.10"
 	v010300UpgradeName  = "v1.3.0" // retained for testy
-
+	v0102015UpgradeName = "v1.2.15"
 )
 
 func setUpgradeHandlers(app *Quicksilver) {
@@ -30,6 +30,7 @@ func setUpgradeHandlers(app *Quicksilver) {
 	app.UpgradeKeeper.SetUpgradeHandler(v010207UpgradeName, v010207UpgradeHandler(app))
 	app.UpgradeKeeper.SetUpgradeHandler(v010209UpgradeName, v010209UpgradeHandler(app))
 	app.UpgradeKeeper.SetUpgradeHandler(v0102010UpgradeName, noOpUpgradeHandler(app))
+	app.UpgradeKeeper.SetUpgradeHandler(v0102015UpgradeName, noOpUpgradeHandler(app))
 
 	// When a planned update height is reached, the old binary will panic
 	// writing on disk the height and name of the update that triggered it

--- a/x/interchainstaking/keeper/ibc_packet_handlers.go
+++ b/x/interchainstaking/keeper/ibc_packet_handlers.go
@@ -745,7 +745,13 @@ func (k *Keeper) HandleBeginRedelegate(ctx sdk.Context, msg sdk.Msg, completion 
 	record, found := k.GetRedelegationRecord(ctx, zone.ChainId, redelegateMsg.ValidatorSrcAddress, redelegateMsg.ValidatorDstAddress, epochNumber)
 	if !found {
 		k.Logger(ctx).Error("unable to find redelegation record", "chain", zone.ChainId, "source", redelegateMsg.ValidatorSrcAddress, "dst", redelegateMsg.ValidatorDstAddress, "epoch", epochNumber)
-		return fmt.Errorf("unable to find redelegation record for chain %s, src: %s, dst: %s, at epoch %d", zone.ChainId, redelegateMsg.ValidatorSrcAddress, redelegateMsg.ValidatorDstAddress, epochNumber)
+		k.Logger(ctx).Error("creating the redelegation record", "chain", zone.ChainId, "source", redelegateMsg.ValidatorSrcAddress, "dst", redelegateMsg.ValidatorDstAddress, "epoch", epochNumber)
+		record = types.RedelegationRecord{
+			ChainId:     zone.ChainId,
+			EpochNumber: epochNumber,
+			Source:      redelegateMsg.ValidatorSrcAddress,
+			Destination: redelegateMsg.ValidatorDstAddress,
+		}
 	}
 	k.Logger(ctx).Info("updating redelegation record with completion time", "completion", completion)
 	record.CompletionTime = completion


### PR DESCRIPTION
## 1. Summary
Fixes # (issue)
- ensure the redelegation msgs are unique
- handle for GC redelegations in case of succesful `MsgBeginRedelegate`

<!-- What are you changing, removing, or adding in this review? -->

## 2.Type of change

<!--  Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## 3. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 4. How to test/use
- `TestRemoveDuplicates`
- `TestReceiveAckForBeginRedelegate`

<!-- How can people test/use this? -->

## 5. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 6. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 7. Future Work (optional)

<!-- Describe follow-up work, if any. -->