### PR TITLE
don't fail hard on zero tvl

### DIFF
--- a/x/participationrewards/keeper/hooks.go
+++ b/x/participationrewards/keeper/hooks.go
@@ -78,8 +78,8 @@ func (k *Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ int64)
 		}
 
 		if err := k.AllocateZoneRewards(ctx, tvs, *allocation); err != nil {
-			k.Logger(ctx).Error(err.Error())
-			return err
+			k.Logger(ctx).Error("unable to allocate: tvl is zero", "error", err.Error())
+			return nil
 		}
 
 		if !allocation.Lockup.IsZero() {


### PR DESCRIPTION
- in a situation where we have been unable to obtain TVLs for any zones (i.e. connection to osmosis is down at the epoch boundary), we shouldn't cause the epoch hook to fail and roll back, but be okay with a zero allocation this epoch.

This is unlikely to happen in production, but not having it means that if this situation does arise the following epoch will also be affected due to not resetting the epoch boundary heights for each zone.