### PR TITLE
chore: run workflows for unstable branches

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -9,8 +9,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "develop"
-      - "main"
+      - main
+      - develop
+      - unstable
+      - unstable-v1.5
 
 # This workflow makes x86_64 for windows, and linux.
 

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - develop
+      - unstable
+      - unstable-v1.5
   pull_request:
 permissions:
   contents: read


### PR DESCRIPTION
Run test workflows on pushes to  `unstable*` branches so that we can get regular CodeCov reports for them